### PR TITLE
feat(skills): ✨ Implement agent skill installer for Claude Code

### DIFF
--- a/src/akira/cli.py
+++ b/src/akira/cli.py
@@ -9,7 +9,7 @@ import typer
 
 from akira.config import DEFAULT_AGENT, DEFAULT_OUTPUT_DIR, SUPPORTED_AGENTS
 from akira.detect import scan_project, write_stack_markdown
-from akira.skills import generate_skills
+from akira.skills import generate_skills, install_claude_skills
 
 app = typer.Typer(
     help="Akira detects project context and generates agent skills.",
@@ -73,6 +73,9 @@ def detect(
     stack = scan_project(path)
     stack_path = write_stack_markdown(output, stack)
     skill_paths = generate_skills(stack, output)
+    installed_paths = ()
+    if agent == "claude-code":
+        installed_paths = install_claude_skills(path, output)
 
     typer.echo(f"Project path: {path}")
     typer.echo(f"Agent: {agent}")
@@ -80,6 +83,9 @@ def detect(
     typer.echo(f"Wrote: {stack_path}")
     for skill in skill_paths:
         typer.echo(f"Wrote: {skill.path}")
+    for installed in installed_paths:
+        if installed.status in {"installed", "updated"}:
+            typer.echo(f"{installed.status.title()}: {installed.path}")
 
 
 def main() -> None:

--- a/src/akira/skills/__init__.py
+++ b/src/akira/skills/__init__.py
@@ -1,5 +1,17 @@
 """Agent skill generation package."""
 
 from akira.skills.generator import GeneratedSkill, SkillGenerator, generate_skills
+from akira.skills.installer import (
+    ClaudeSkillInstaller,
+    InstalledSkillFile,
+    install_claude_skills,
+)
 
-__all__ = ["GeneratedSkill", "SkillGenerator", "generate_skills"]
+__all__ = [
+    "ClaudeSkillInstaller",
+    "GeneratedSkill",
+    "InstalledSkillFile",
+    "SkillGenerator",
+    "generate_skills",
+    "install_claude_skills",
+]

--- a/src/akira/skills/installer.py
+++ b/src/akira/skills/installer.py
@@ -23,7 +23,11 @@ class ClaudeSkillInstaller:
 
     target_relative_dir = Path(".claude") / "skills" / "akira"
 
-    def install(self, project_root: Path, output_dir: Path) -> tuple[InstalledSkillFile, ...]:
+    def install(
+        self,
+        project_root: Path,
+        output_dir: Path,
+    ) -> tuple[InstalledSkillFile, ...]:
         """Copy generated Akira output into project_root/.claude/skills/akira."""
         source_files = _generated_source_files(output_dir)
         target_dir = project_root / self.target_relative_dir
@@ -101,7 +105,10 @@ def _rewrite_router_references_for_install(content: bytes) -> bytes:
     )
 
 
-def _stale_installed_files(target_dir: Path, desired_paths: set[Path]) -> tuple[Path, ...]:
+def _stale_installed_files(
+    target_dir: Path,
+    desired_paths: set[Path],
+) -> tuple[Path, ...]:
     if not target_dir.exists():
         return ()
 

--- a/src/akira/skills/installer.py
+++ b/src/akira/skills/installer.py
@@ -1,0 +1,130 @@
+"""Install generated Akira skills into agent-specific skill directories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+InstallStatus = Literal["installed", "updated", "unchanged", "removed"]
+
+
+@dataclass(frozen=True)
+class InstalledSkillFile:
+    """A file touched while installing generated skills."""
+
+    path: Path
+    status: InstallStatus
+
+
+class ClaudeSkillInstaller:
+    """Install generated Akira skills for Claude Code."""
+
+    target_relative_dir = Path(".claude") / "skills" / "akira"
+
+    def install(self, project_root: Path, output_dir: Path) -> tuple[InstalledSkillFile, ...]:
+        """Copy generated Akira output into project_root/.claude/skills/akira."""
+        source_files = _generated_source_files(output_dir)
+        target_dir = project_root / self.target_relative_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        results: list[InstalledSkillFile] = []
+        desired_paths = set(source_files)
+
+        for relative_path, source_path in sorted(
+            source_files.items(),
+            key=lambda item: item[0].as_posix(),
+        ):
+            target_path = target_dir / relative_path
+            status = _copy_file(source_path, target_path, relative_path)
+            results.append(InstalledSkillFile(target_path, status))
+
+        for stale_path in _stale_installed_files(target_dir, desired_paths):
+            stale_path.unlink()
+            results.append(InstalledSkillFile(stale_path, "removed"))
+
+        _remove_empty_directories(target_dir)
+        return tuple(results)
+
+
+def install_claude_skills(
+    project_root: Path,
+    output_dir: Path,
+) -> tuple[InstalledSkillFile, ...]:
+    """Install generated Akira skills into Claude Code's project skill directory."""
+    return ClaudeSkillInstaller().install(project_root, output_dir)
+
+
+def _generated_source_files(output_dir: Path) -> dict[Path, Path]:
+    files: dict[Path, Path] = {}
+    skills_dir = output_dir / "skills"
+
+    if skills_dir.exists():
+        for path in skills_dir.rglob("*"):
+            if path.is_file():
+                files[path.relative_to(skills_dir)] = path
+
+    for filename in ("stack.md", "fingerprint.md"):
+        path = output_dir / filename
+        if path.is_file():
+            files[Path(filename)] = path
+
+    return files
+
+
+def _copy_file(
+    source_path: Path,
+    target_path: Path,
+    relative_path: Path,
+) -> InstallStatus:
+    content = source_path.read_bytes()
+    if relative_path == Path("SKILL.md"):
+        content = _rewrite_router_references_for_install(content)
+
+    if target_path.exists():
+        if target_path.read_bytes() == content:
+            return "unchanged"
+        status: InstallStatus = "updated"
+    else:
+        status = "installed"
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_bytes(content)
+    return status
+
+
+def _rewrite_router_references_for_install(content: bytes) -> bytes:
+    return (
+        content.replace(b"../stack.md", b"stack.md")
+        .replace(b"../fingerprint.md", b"fingerprint.md")
+    )
+
+
+def _stale_installed_files(target_dir: Path, desired_paths: set[Path]) -> tuple[Path, ...]:
+    if not target_dir.exists():
+        return ()
+
+    return tuple(
+        sorted(
+            (
+                path
+                for path in target_dir.rglob("*")
+                if path.is_file() and path.relative_to(target_dir) not in desired_paths
+            ),
+            key=lambda path: path.as_posix(),
+        )
+    )
+
+
+def _remove_empty_directories(target_dir: Path) -> None:
+    directories = sorted(
+        (path for path in target_dir.rglob("*") if path.is_dir()),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    )
+    for directory in directories:
+        try:
+            directory.rmdir()
+        except OSError:
+            continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,32 @@ dependencies = ["fastapi==0.115.0"]
     assert f"Wrote: {stack_path}" in result.stdout
 
 
+def test_detect_installs_generated_skills_for_claude_code(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    output_dir = tmp_path / ".akira"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """
+[project]
+requires-python = ">=3.12"
+dependencies = ["pytest==8.0.0"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["detect", "--path", str(project), "--output", str(output_dir)],
+    )
+
+    installed_router = project / ".claude" / "skills" / "akira" / "SKILL.md"
+    installed_stack = project / ".claude" / "skills" / "akira" / "stack.md"
+    assert result.exit_code == 0
+    assert installed_router.exists()
+    assert installed_stack.exists()
+    assert f"Installed: {installed_router}" in result.stdout
+
+
 def test_package_script_points_to_cli_main() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,11 +118,23 @@ dependencies = ["pytest==8.0.0"]
 
     result = runner.invoke(
         app,
-        ["detect", "--path", str(project), "--output", str(output_dir)],
+        [
+            "detect",
+            "--path",
+            str(project),
+            "--output",
+            str(output_dir),
+            "--agent",
+            "claude-code",
+        ],
     )
 
-    installed_router = project / ".claude" / "skills" / "akira" / "SKILL.md"
-    installed_stack = project / ".claude" / "skills" / "akira" / "stack.md"
+    installed_router = (
+        project / ".claude" / "skills" / "akira" / "SKILL.md"
+    )
+    installed_stack = (
+        project / ".claude" / "skills" / "akira" / "stack.md"
+    )
     assert result.exit_code == 0
     assert installed_router.exists()
     assert installed_stack.exists()

--- a/tests/test_skills/test_skill_installer.py
+++ b/tests/test_skills/test_skill_installer.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from akira.skills.installer import install_claude_skills
+
+
+def test_install_claude_skills_copies_generated_tree_and_project_references(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    output = tmp_path / ".akira"
+    project.mkdir()
+    (output / "skills" / "python" / "testing").mkdir(parents=True)
+    (output / "skills" / "SKILL.md").write_text(
+        "Read ../stack.md and ../fingerprint.md",
+        encoding="utf-8",
+    )
+    (output / "skills" / "python" / "SKILL.md").write_text("python", encoding="utf-8")
+    (output / "skills" / "python" / "testing" / "pytest.md").write_text(
+        "pytest",
+        encoding="utf-8",
+    )
+    (output / "stack.md").write_text("stack", encoding="utf-8")
+    (output / "fingerprint.md").write_text("fingerprint", encoding="utf-8")
+
+    installed = install_claude_skills(project, output)
+
+    target = project / ".claude" / "skills" / "akira"
+    assert {item.status for item in installed} == {"installed"}
+    assert (
+        (target / "SKILL.md").read_text(encoding="utf-8")
+        == "Read stack.md and fingerprint.md"
+    )
+    assert (target / "python" / "SKILL.md").read_text(encoding="utf-8") == "python"
+    assert (
+        (target / "python" / "testing" / "pytest.md").read_text(encoding="utf-8")
+        == "pytest"
+    )
+    assert (target / "stack.md").read_text(encoding="utf-8") == "stack"
+    assert (target / "fingerprint.md").read_text(encoding="utf-8") == "fingerprint"
+    assert not (target / "skills" / "SKILL.md").exists()
+
+
+def test_install_claude_skills_is_idempotent_and_updates_changed_files(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    output = tmp_path / ".akira"
+    project.mkdir()
+    (output / "skills").mkdir(parents=True)
+    (output / "skills" / "SKILL.md").write_text("first", encoding="utf-8")
+
+    first = install_claude_skills(project, output)
+    second = install_claude_skills(project, output)
+    (output / "skills" / "SKILL.md").write_text("second", encoding="utf-8")
+    third = install_claude_skills(project, output)
+
+    assert [item.status for item in first] == ["installed"]
+    assert [item.status for item in second] == ["unchanged"]
+    assert [item.status for item in third] == ["updated"]
+    assert (
+        project / ".claude" / "skills" / "akira" / "SKILL.md"
+    ).read_text(encoding="utf-8") == "second"
+
+
+def test_install_claude_skills_removes_stale_akira_files_but_preserves_other_skills(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    output = tmp_path / ".akira"
+    project.mkdir()
+    (output / "skills").mkdir(parents=True)
+    (output / "skills" / "SKILL.md").write_text("router", encoding="utf-8")
+    target = project / ".claude" / "skills"
+    (target / "akira" / "python" / "testing").mkdir(parents=True)
+    (target / "akira" / "python" / "testing" / "old.md").write_text(
+        "old",
+        encoding="utf-8",
+    )
+    (target / "custom" / "SKILL.md").parent.mkdir(parents=True)
+    (target / "custom" / "SKILL.md").write_text("custom", encoding="utf-8")
+
+    installed = install_claude_skills(project, output)
+
+    assert (target / "akira" / "SKILL.md").exists()
+    assert not (target / "akira" / "python" / "testing" / "old.md").exists()
+    assert (target / "custom" / "SKILL.md").read_text(encoding="utf-8") == "custom"
+    assert any(item.status == "removed" for item in installed)

--- a/tests/test_skills/test_skill_installer.py
+++ b/tests/test_skills/test_skill_installer.py
@@ -16,7 +16,10 @@ def test_install_claude_skills_copies_generated_tree_and_project_references(
         "Read ../stack.md and ../fingerprint.md",
         encoding="utf-8",
     )
-    (output / "skills" / "python" / "SKILL.md").write_text("python", encoding="utf-8")
+    (output / "skills" / "python" / "SKILL.md").write_text(
+        "python",
+        encoding="utf-8",
+    )
     (output / "skills" / "python" / "testing" / "pytest.md").write_text(
         "pytest",
         encoding="utf-8",


### PR DESCRIPTION
* Added `install_claude_skills` function to install generated skills into Claude Code's project directory.
* Introduced `ClaudeSkillInstaller` class to handle the installation process.
* Updated CLI to invoke skill installation when detecting projects for Claude Code.
* Added tests to verify installation functionality and idempotency of skill updates.