### PR TITLE
Dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,7 @@ pythonpath = ["src"]
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+exclude = [
+    "tests/fixtures/style_projects/mixed/**",
+    "tests/fixtures/style_projects/with_syntax_error/**",
+]

--- a/src/akira/cli.py
+++ b/src/akira/cli.py
@@ -134,7 +134,7 @@ def fingerprint(
         ),
     ] = DEFAULT_OUTPUT_DIR,
 ) -> None:
-    """Collect source files for developer fingerprint analysis."""
+    """Analyze source files and write fingerprint.md output."""
     analysis = fingerprint_project(path, sample_size=sample_size, exclude=exclude or ())
     fingerprint_path = write_fingerprint_markdown(
         output,

--- a/src/akira/cli.py
+++ b/src/akira/cli.py
@@ -9,7 +9,7 @@ import typer
 
 from akira.config import DEFAULT_AGENT, DEFAULT_OUTPUT_DIR, SUPPORTED_AGENTS
 from akira.detect import scan_project, write_stack_markdown
-from akira.fingerprint import fingerprint_project
+from akira.fingerprint import fingerprint_project, write_fingerprint_markdown
 from akira.skills import generate_skills, install_claude_skills
 
 app = typer.Typer(
@@ -121,12 +121,30 @@ def fingerprint(
             help="Project-relative path or glob to exclude. May be passed multiple times.",
         ),
     ] = None,
+    output: Annotated[
+        Path,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Directory where Akira will write generated files.",
+            file_okay=False,
+            dir_okay=True,
+            writable=True,
+            resolve_path=True,
+        ),
+    ] = DEFAULT_OUTPUT_DIR,
 ) -> None:
     """Collect source files for developer fingerprint analysis."""
     analysis = fingerprint_project(path, sample_size=sample_size, exclude=exclude or ())
+    fingerprint_path = write_fingerprint_markdown(
+        output,
+        analysis,
+        sample_size=sample_size,
+    )
 
     typer.echo(f"Project path: {path}")
     typer.echo(f"Sample size: {sample_size}")
+    typer.echo(f"Output: {output}")
     for pattern in exclude or ():
         typer.echo(f"Exclude: {pattern}")
     typer.echo(f"Files analyzed: {len(analysis.files)}")
@@ -134,6 +152,7 @@ def fingerprint(
     typer.echo(f"Parse failures: {len(analysis.failed_files)}")
     typer.echo(f"Patterns extracted: {len(analysis.patterns)}")
     typer.echo(f"Confidence: {analysis.confidence:.2f}")
+    typer.echo(f"Wrote: {fingerprint_path}")
 
 
 def main() -> None:

--- a/src/akira/cli.py
+++ b/src/akira/cli.py
@@ -9,7 +9,7 @@ import typer
 
 from akira.config import DEFAULT_AGENT, DEFAULT_OUTPUT_DIR, SUPPORTED_AGENTS
 from akira.detect import scan_project, write_stack_markdown
-from akira.fingerprint import analyze_project
+from akira.fingerprint import fingerprint_project
 from akira.skills import generate_skills, install_claude_skills
 
 app = typer.Typer(
@@ -123,7 +123,7 @@ def fingerprint(
     ] = None,
 ) -> None:
     """Collect source files for developer fingerprint analysis."""
-    analysis = analyze_project(path, sample_size=sample_size, exclude=exclude or ())
+    analysis = fingerprint_project(path, sample_size=sample_size, exclude=exclude or ())
 
     typer.echo(f"Project path: {path}")
     typer.echo(f"Sample size: {sample_size}")
@@ -132,6 +132,8 @@ def fingerprint(
     typer.echo(f"Files analyzed: {len(analysis.files)}")
     typer.echo(f"Parsed: {len(analysis.parsed_files)}")
     typer.echo(f"Parse failures: {len(analysis.failed_files)}")
+    typer.echo(f"Patterns extracted: {len(analysis.patterns)}")
+    typer.echo(f"Confidence: {analysis.confidence:.2f}")
 
 
 def main() -> None:

--- a/src/akira/fingerprint/__init__.py
+++ b/src/akira/fingerprint/__init__.py
@@ -1,11 +1,19 @@
 """Developer fingerprint package."""
 
-from akira.fingerprint.analyzer import analyze_project, collect_python_files
-from akira.fingerprint.models import FingerprintAnalysis, SourceFile
+from akira.fingerprint.analyzer import (
+    analyze_project,
+    collect_python_files,
+    extract_style_patterns,
+    fingerprint_project,
+)
+from akira.fingerprint.models import FingerprintAnalysis, SourceFile, StylePattern
 
 __all__ = [
     "FingerprintAnalysis",
     "SourceFile",
+    "StylePattern",
     "analyze_project",
     "collect_python_files",
+    "extract_style_patterns",
+    "fingerprint_project",
 ]

--- a/src/akira/fingerprint/__init__.py
+++ b/src/akira/fingerprint/__init__.py
@@ -9,6 +9,7 @@ from akira.fingerprint.analyzer import (
 from akira.fingerprint.models import FingerprintAnalysis, SourceFile, StylePattern
 from akira.fingerprint.renderer import (
     build_fingerprint_sections,
+    format_fingerprint_value,
     render_fingerprint_markdown,
     write_fingerprint_markdown,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "collect_python_files",
     "extract_style_patterns",
     "fingerprint_project",
+    "format_fingerprint_value",
     "render_fingerprint_markdown",
     "write_fingerprint_markdown",
 ]

--- a/src/akira/fingerprint/__init__.py
+++ b/src/akira/fingerprint/__init__.py
@@ -7,13 +7,21 @@ from akira.fingerprint.analyzer import (
     fingerprint_project,
 )
 from akira.fingerprint.models import FingerprintAnalysis, SourceFile, StylePattern
+from akira.fingerprint.renderer import (
+    build_fingerprint_sections,
+    render_fingerprint_markdown,
+    write_fingerprint_markdown,
+)
 
 __all__ = [
     "FingerprintAnalysis",
     "SourceFile",
     "StylePattern",
     "analyze_project",
+    "build_fingerprint_sections",
     "collect_python_files",
     "extract_style_patterns",
     "fingerprint_project",
+    "render_fingerprint_markdown",
+    "write_fingerprint_markdown",
 ]

--- a/src/akira/fingerprint/analyzer.py
+++ b/src/akira/fingerprint/analyzer.py
@@ -9,7 +9,18 @@ import tokenize
 from pathlib import Path
 from typing import Iterable
 
-from akira.fingerprint.extractors import comments, imports, naming, spacing
+from akira.fingerprint.extractors import (
+    comments,
+    docstrings,
+    error_handling,
+    imports,
+    naming,
+    organization,
+    spacing,
+    strings,
+    structure,
+    typing,
+)
 from akira.fingerprint.models import FingerprintAnalysis, SourceFile, StylePattern
 
 DEFAULT_EXCLUDED_DIRS = {
@@ -56,7 +67,18 @@ def analyze_project(
 
 def extract_style_patterns(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
     """Run all v1 practical fingerprint extractors over a source sample."""
-    extractors = (spacing.extract, naming.extract, imports.extract, comments.extract)
+    extractors = (
+        spacing.extract,
+        naming.extract,
+        imports.extract,
+        comments.extract,
+        typing.extract,
+        structure.extract,
+        docstrings.extract,
+        organization.extract,
+        error_handling.extract,
+        strings.extract,
+    )
     patterns: list[StylePattern] = []
     for extractor in extractors:
         patterns.extend(extractor(analysis))

--- a/src/akira/fingerprint/analyzer.py
+++ b/src/akira/fingerprint/analyzer.py
@@ -1,4 +1,4 @@
-"""Collect Python source files for developer fingerprint extractors."""
+"""Collect Python source files and extract developer fingerprint patterns."""
 
 from __future__ import annotations
 
@@ -9,7 +9,8 @@ import tokenize
 from pathlib import Path
 from typing import Iterable
 
-from akira.fingerprint.models import FingerprintAnalysis, SourceFile
+from akira.fingerprint.extractors import comments, imports, naming, spacing
+from akira.fingerprint.models import FingerprintAnalysis, SourceFile, StylePattern
 
 DEFAULT_EXCLUDED_DIRS = {
     ".akira",
@@ -51,6 +52,30 @@ def analyze_project(
         for path in collect_python_files(root, sample_size=sample_size, exclude=exclude)
     )
     return FingerprintAnalysis(project_root=root, files=files)
+
+
+def extract_style_patterns(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Run all v1 practical fingerprint extractors over a source sample."""
+    extractors = (spacing.extract, naming.extract, imports.extract, comments.extract)
+    patterns: list[StylePattern] = []
+    for extractor in extractors:
+        patterns.extend(extractor(analysis))
+    return tuple(patterns)
+
+
+def fingerprint_project(
+    project_root: Path,
+    *,
+    sample_size: int = 20,
+    exclude: Iterable[str] = (),
+) -> FingerprintAnalysis:
+    """Collect files and attach structured style patterns."""
+    analysis = analyze_project(project_root, sample_size=sample_size, exclude=exclude)
+    return FingerprintAnalysis(
+        project_root=analysis.project_root,
+        files=analysis.files,
+        patterns=extract_style_patterns(analysis),
+    )
 
 
 def collect_python_files(

--- a/src/akira/fingerprint/extractors/__init__.py
+++ b/src/akira/fingerprint/extractors/__init__.py
@@ -1,2 +1,5 @@
 """Fingerprint extractor implementations."""
 
+from akira.fingerprint.extractors import comments, imports, naming, spacing
+
+__all__ = ["comments", "imports", "naming", "spacing"]

--- a/src/akira/fingerprint/extractors/__init__.py
+++ b/src/akira/fingerprint/extractors/__init__.py
@@ -1,5 +1,27 @@
 """Fingerprint extractor implementations."""
 
-from akira.fingerprint.extractors import comments, imports, naming, spacing
+from akira.fingerprint.extractors import (
+    comments,
+    docstrings,
+    error_handling,
+    imports,
+    naming,
+    organization,
+    spacing,
+    strings,
+    structure,
+    typing,
+)
 
-__all__ = ["comments", "imports", "naming", "spacing"]
+__all__ = [
+    "comments",
+    "docstrings",
+    "error_handling",
+    "imports",
+    "naming",
+    "organization",
+    "spacing",
+    "strings",
+    "structure",
+    "typing",
+]

--- a/src/akira/fingerprint/extractors/_common.py
+++ b/src/akira/fingerprint/extractors/_common.py
@@ -1,0 +1,90 @@
+"""Shared helpers for fingerprint extractor implementations."""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, TypeVar
+
+from akira.fingerprint.models import StylePattern
+
+T = TypeVar("T")
+
+SNAKE_CASE_RE = re.compile(r"^_?[a-z][a-z0-9_]*_?$|^__$")
+PASCAL_CASE_RE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+UPPER_SNAKE_CASE_RE = re.compile(r"^_?[A-Z][A-Z0-9_]*_?$")
+BOOLEAN_PREFIXES = ("is_", "has_", "can_", "should_", "use_", "enable_")
+
+
+def clamp_confidence(value: float) -> float:
+    """Keep confidence values stable and renderer-friendly."""
+    return round(max(0.0, min(1.0, value)), 2)
+
+
+def modal_pattern(values: Iterable[T]) -> tuple[T | None, float, int]:
+    """Return the dominant value, its share, and the number of observations."""
+    items = list(values)
+    if not items:
+        return None, 0.0, 0
+
+    counter = Counter(items)
+    value, count = sorted(counter.items(), key=lambda item: (-item[1], str(item[0])))[0]
+    return value, count / len(items), len(items)
+
+
+def make_pattern(
+    *,
+    dimension: str,
+    name: str,
+    value: object,
+    confidence: float,
+    samples: int,
+    description: str,
+    evidence: dict[str, object] | None = None,
+) -> StylePattern:
+    """Create a normalized style pattern result."""
+    return StylePattern(
+        dimension=dimension,
+        name=name,
+        value=value,
+        confidence=clamp_confidence(confidence),
+        samples=samples,
+        description=description,
+        evidence=evidence or {},
+    )
+
+
+def blank_lines_before(lines: list[str], line_number: int) -> int:
+    """Count blank lines immediately before a 1-based line number."""
+    index = line_number - 2
+    count = 0
+    while index >= 0 and not lines[index].strip():
+        count += 1
+        index -= 1
+    return count
+
+
+def blank_lines_between(lines: list[str], start_line: int, end_line: int) -> int:
+    """Count blank physical lines between two 1-based source positions."""
+    if end_line <= start_line:
+        return 0
+    return sum(1 for line in lines[start_line:end_line - 1] if not line.strip())
+
+
+def iter_function_defs(tree: ast.AST) -> Iterable[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Yield all function definitions in deterministic AST order."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            yield node
+
+
+def module_name_from_path(relative_path: Path) -> str:
+    """Infer the most useful local import root from a project-relative path."""
+    parts = relative_path.with_suffix("").parts
+    if "src" in parts:
+        src_index = parts.index("src")
+        if src_index + 1 < len(parts):
+            return parts[src_index + 1]
+    return parts[0] if parts else ""

--- a/src/akira/fingerprint/extractors/comments.py
+++ b/src/akira/fingerprint/extractors/comments.py
@@ -1,0 +1,143 @@
+"""Comment style extractor."""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+from collections import Counter
+
+from akira.fingerprint.extractors._common import make_pattern, modal_pattern
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+SECTION_RE = re.compile(r"^#\s*[-=]{3,}\s*[^-=#].*?\s*[-=]{3,}\s*$")
+TODO_AUTHOR_RE = re.compile(r"#\s*TODO\([^)]+\):\s*\S+", re.IGNORECASE)
+TODO_ANY_RE = re.compile(r"#\s*TODO\b", re.IGNORECASE)
+PORTUGUESE_HINTS = {
+    "para",
+    "quando",
+    "deve",
+    "nao",
+    "não",
+    "com",
+    "sem",
+    "arquivo",
+    "funcao",
+    "função",
+}
+ENGLISH_HINTS = {
+    "the",
+    "when",
+    "with",
+    "without",
+    "return",
+    "use",
+    "file",
+    "function",
+    "section",
+}
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract section, inline, language, and TODO comment preferences."""
+    comments: list[dict[str, object]] = []
+    code_lines = 0
+
+    for source in analysis.files:
+        lines = source.text.splitlines()
+        code_lines += sum(1 for line in lines if line.strip() and not line.lstrip().startswith("#"))
+        comments.extend(_comments_for_text(source.text, lines))
+
+    if not comments:
+        return ()
+
+    section_comments = [comment for comment in comments if comment["section"]]
+    inline_comments = [comment for comment in comments if comment["inline"]]
+    todos = [comment for comment in comments if TODO_ANY_RE.search(str(comment["text"]))]
+    formatted_todos = [comment for comment in todos if TODO_AUTHOR_RE.search(str(comment["text"]))]
+    languages = [_language_hint(str(comment["text"])) for comment in comments]
+    language, language_share, language_samples = modal_pattern(languages)
+
+    patterns = [
+        make_pattern(
+            dimension="comments",
+            name="section_separators",
+            value="hash_dash_section_separator",
+            confidence=len(section_comments) / len(comments),
+            samples=len(comments),
+            description="Section separators use comments such as '# --- Section ---'.",
+            evidence={"count": len(section_comments)},
+        ),
+        make_pattern(
+            dimension="comments",
+            name="inline_comment_frequency",
+            value="low" if _inline_frequency(inline_comments, code_lines) < 0.1 else "present",
+            confidence=1.0 - min(1.0, _inline_frequency(inline_comments, code_lines)),
+            samples=max(code_lines, 1),
+            description="Inline comments are measured relative to executable code lines.",
+            evidence={"inline_comments": len(inline_comments), "code_lines": code_lines},
+        ),
+        make_pattern(
+            dimension="comments",
+            name="language",
+            value=language,
+            confidence=language_share,
+            samples=language_samples,
+            description="Dominant natural-language hint in comments.",
+            evidence={"distribution": dict(sorted(Counter(languages).items()))},
+        ),
+    ]
+
+    if todos:
+        patterns.append(
+            make_pattern(
+                dimension="comments",
+                name="todo_format",
+                value="TODO(author): description",
+                confidence=len(formatted_todos) / len(todos),
+                samples=len(todos),
+                description="TODO comments include an owner tag and a description.",
+                evidence={"todos": len(todos), "formatted": len(formatted_todos)},
+            )
+        )
+
+    return tuple(patterns)
+
+
+def _comments_for_text(text: str, lines: list[str]) -> list[dict[str, object]]:
+    comments: list[dict[str, object]] = []
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        for token in tokens:
+            if token.type != tokenize.COMMENT:
+                continue
+            line = lines[token.start[0] - 1] if token.start[0] <= len(lines) else ""
+            before_comment = line[: token.start[1]]
+            comments.append(
+                {
+                    "text": token.string,
+                    "inline": bool(before_comment.strip()),
+                    "section": SECTION_RE.match(token.string.strip()) is not None,
+                }
+            )
+    except tokenize.TokenError:
+        return comments
+    return comments
+
+
+def _inline_frequency(inline_comments: list[dict[str, object]], code_lines: int) -> float:
+    if code_lines <= 0:
+        return 0.0
+    return len(inline_comments) / code_lines
+
+
+def _language_hint(comment: str) -> str:
+    normalized = re.sub(r"[^\w\sãõáéíóúçâêôà-]", " ", comment.lower())
+    words = set(normalized.split())
+    portuguese_score = len(words & PORTUGUESE_HINTS)
+    english_score = len(words & ENGLISH_HINTS)
+    if portuguese_score > english_score:
+        return "portuguese"
+    if english_score > portuguese_score:
+        return "english"
+    return "unknown"

--- a/src/akira/fingerprint/extractors/docstrings.py
+++ b/src/akira/fingerprint/extractors/docstrings.py
@@ -1,0 +1,119 @@
+"""Docstring style and coverage extractor."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+
+from akira.fingerprint.extractors._common import (
+    make_pattern,
+    modal_pattern,
+)
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract docstring coverage, style, and public/private behavior."""
+    public_defs: list[ast.AST] = []
+    private_defs: list[ast.AST] = []
+    classes: list[ast.ClassDef] = []
+    functions: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    styles: list[str] = []
+
+    for source in analysis.parsed_files:
+        if source.tree is None:
+            continue
+
+        for node in ast.walk(source.tree):
+            if isinstance(node, ast.ClassDef):
+                classes.append(node)
+                _append_by_visibility(node, public_defs, private_defs)
+                styles.extend(_docstring_style(node))
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                functions.append(node)
+                _append_by_visibility(node, public_defs, private_defs)
+                styles.extend(_docstring_style(node))
+
+    patterns: list[StylePattern] = []
+    patterns.extend(_coverage_pattern("public_docstrings", public_defs))
+    patterns.extend(_private_behavior_pattern(private_defs))
+    patterns.extend(_coverage_pattern("class_docstrings", classes))
+    patterns.extend(_coverage_pattern("function_docstrings", functions))
+    patterns.extend(_style_pattern(styles))
+    return tuple(patterns)
+
+
+def _coverage_pattern(name: str, nodes: list[ast.AST]) -> tuple[StylePattern, ...]:
+    if not nodes:
+        return ()
+
+    documented = sum(1 for node in nodes if ast.get_docstring(node) is not None)
+    return (
+        make_pattern(
+            dimension="docstrings",
+            name=name,
+            value="documented" if documented / len(nodes) >= 0.5 else "sparse",
+            confidence=documented / len(nodes),
+            samples=len(nodes),
+            description=f"Docstring coverage for {name.replace('_', ' ')}.",
+            evidence={"documented": documented, "total": len(nodes)},
+        ),
+    )
+
+
+def _private_behavior_pattern(nodes: list[ast.AST]) -> tuple[StylePattern, ...]:
+    if not nodes:
+        return ()
+
+    undocumented = sum(1 for node in nodes if ast.get_docstring(node) is None)
+    return (
+        make_pattern(
+            dimension="docstrings",
+            name="private_docstring_behavior",
+            value="omit_private_docstrings",
+            confidence=undocumented / len(nodes),
+            samples=len(nodes),
+            description="Private functions and classes omit docstrings.",
+            evidence={"undocumented_private": undocumented, "private_defs": len(nodes)},
+        ),
+    )
+
+
+def _style_pattern(styles: list[str]) -> tuple[StylePattern, ...]:
+    style, share, samples = modal_pattern(styles)
+    if style is None:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="docstrings",
+            name="docstring_style",
+            value=style,
+            confidence=share,
+            samples=samples,
+            description="Dominant docstring format among documented definitions.",
+            evidence={"distribution": dict(sorted(Counter(styles).items()))},
+        ),
+    )
+
+
+def _append_by_visibility(node: ast.AST, public_defs: list[ast.AST], private_defs: list[ast.AST]) -> None:
+    name = getattr(node, "name", "")
+    if name.startswith("_") and not name.startswith("__"):
+        private_defs.append(node)
+    else:
+        public_defs.append(node)
+
+
+def _docstring_style(node: ast.AST) -> list[str]:
+    docstring = ast.get_docstring(node)
+    if not docstring:
+        return []
+
+    if "Args:" in docstring or "Returns:" in docstring or "Raises:" in docstring:
+        return ["google"]
+    if "Parameters\n" in docstring and "-------" in docstring:
+        return ["numpy"]
+    if ":param " in docstring or ":returns:" in docstring or ":raises " in docstring:
+        return ["sphinx"]
+    return ["plain"]

--- a/src/akira/fingerprint/extractors/error_handling.py
+++ b/src/akira/fingerprint/extractors/error_handling.py
@@ -1,0 +1,92 @@
+"""Error-handling style extractor."""
+
+from __future__ import annotations
+
+import ast
+
+from akira.fingerprint.extractors._common import make_pattern
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+GENERIC_EXCEPTIONS = {"BaseException", "Exception"}
+LOG_METHODS = {"debug", "info", "warning", "warn", "error", "exception", "critical"}
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract exception specificity and logging behavior in except handlers."""
+    handlers: list[ast.ExceptHandler] = []
+    for source in analysis.parsed_files:
+        if source.tree is not None:
+            handlers.extend(
+                node for node in ast.walk(source.tree) if isinstance(node, ast.ExceptHandler)
+            )
+
+    if not handlers:
+        return ()
+
+    specific = sum(1 for handler in handlers if _is_specific_exception(handler))
+    logged = sum(1 for handler in handlers if _logs_on_catch(handler))
+    reraised = sum(1 for handler in handlers if _reraises(handler))
+
+    return (
+        make_pattern(
+            dimension="error_handling",
+            name="exception_specificity",
+            value="specific_exceptions",
+            confidence=specific / len(handlers),
+            samples=len(handlers),
+            description="Except handlers avoid bare except and generic Exception catches.",
+            evidence={"specific": specific, "handlers": len(handlers)},
+        ),
+        make_pattern(
+            dimension="error_handling",
+            name="logging_on_catch",
+            value="logs_caught_exceptions",
+            confidence=logged / len(handlers),
+            samples=len(handlers),
+            description="Except handlers log caught exceptions.",
+            evidence={"logged": logged, "handlers": len(handlers)},
+        ),
+        make_pattern(
+            dimension="error_handling",
+            name="reraising",
+            value="reraises_after_catch",
+            confidence=reraised / len(handlers),
+            samples=len(handlers),
+            description="Except handlers re-raise after local handling.",
+            evidence={"reraised": reraised, "handlers": len(handlers)},
+        ),
+    )
+
+
+def _is_specific_exception(handler: ast.ExceptHandler) -> bool:
+    if handler.type is None:
+        return False
+    names = _exception_names(handler.type)
+    return bool(names) and all(name not in GENERIC_EXCEPTIONS for name in names)
+
+
+def _exception_names(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Name):
+        return [node.id]
+    if isinstance(node, ast.Attribute):
+        return [node.attr]
+    if isinstance(node, ast.Tuple):
+        names: list[str] = []
+        for element in node.elts:
+            names.extend(_exception_names(element))
+        return names
+    return []
+
+
+def _logs_on_catch(handler: ast.ExceptHandler) -> bool:
+    for node in ast.walk(handler):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if isinstance(function, ast.Attribute) and function.attr in LOG_METHODS:
+            return True
+    return False
+
+
+def _reraises(handler: ast.ExceptHandler) -> bool:
+    return any(isinstance(node, ast.Raise) for node in ast.walk(handler))

--- a/src/akira/fingerprint/extractors/imports.py
+++ b/src/akira/fingerprint/extractors/imports.py
@@ -1,0 +1,143 @@
+"""Import style extractor."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections import Counter, defaultdict
+
+from akira.fingerprint.extractors._common import make_pattern, module_name_from_path
+from akira.fingerprint.models import FingerprintAnalysis, SourceFile, StylePattern
+
+GROUP_ORDER = {"stdlib": 0, "third_party": 1, "local": 2}
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract import grouping, ordering, and import statement preferences."""
+    local_roots = {
+        module_name_from_path(source.relative_path)
+        for source in analysis.parsed_files
+        if module_name_from_path(source.relative_path)
+    }
+    imports_by_file = [_file_imports(source, local_roots) for source in analysis.parsed_files]
+    non_empty = [imports for imports in imports_by_file if imports]
+    if not non_empty:
+        return ()
+
+    all_imports = [item for imports in non_empty for item in imports]
+    ordered_files = sum(1 for imports in non_empty if _groups_are_ordered(imports))
+    alphabetized_files = sum(1 for imports in non_empty if _imports_are_alphabetized(imports))
+    one_per_line = sum(1 for item in all_imports if item["one_per_line"])
+    no_wildcards = sum(1 for item in all_imports if not item["wildcard"])
+    no_relative = sum(1 for item in all_imports if not item["relative"])
+    group_sequences = [tuple(dict.fromkeys(item["group"] for item in imports)) for imports in non_empty]
+    sequence_counts = Counter(group_sequences)
+    dominant_sequence, dominant_count = sorted(
+        sequence_counts.items(), key=lambda item: (-item[1], item[0])
+    )[0]
+
+    return (
+        make_pattern(
+            dimension="imports",
+            name="grouping_order",
+            value=dominant_sequence,
+            confidence=ordered_files / len(non_empty),
+            samples=len(non_empty),
+            description="Import groups follow a stable stdlib, third-party, local order.",
+            evidence={"sequences": {" > ".join(key): count for key, count in sequence_counts.items()}},
+        ),
+        make_pattern(
+            dimension="imports",
+            name="alphabetical_order",
+            value="alphabetical_within_groups",
+            confidence=alphabetized_files / len(non_empty),
+            samples=len(non_empty),
+            description="Imports are alphabetized within their import groups.",
+        ),
+        make_pattern(
+            dimension="imports",
+            name="one_import_per_line",
+            value=True,
+            confidence=one_per_line / len(all_imports),
+            samples=len(all_imports),
+            description="Import statements avoid comma-packed imports.",
+        ),
+        make_pattern(
+            dimension="imports",
+            name="wildcard_usage",
+            value="avoid_wildcards",
+            confidence=no_wildcards / len(all_imports),
+            samples=len(all_imports),
+            description="Wildcard imports are avoided.",
+        ),
+        make_pattern(
+            dimension="imports",
+            name="relative_imports",
+            value="avoid_relative_imports",
+            confidence=no_relative / len(all_imports),
+            samples=len(all_imports),
+            description="Imports prefer absolute module paths over relative imports.",
+        ),
+    )
+
+
+def _file_imports(source: SourceFile, local_roots: set[str]) -> list[dict[str, object]]:
+    if source.tree is None:
+        return []
+
+    module = source.tree
+    assert isinstance(module, ast.Module)
+    imports: list[dict[str, object]] = []
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Import | ast.ImportFrom):
+            continue
+
+        module_name = _imported_module_name(node)
+        imports.append(
+            {
+                "line": node.lineno,
+                "name": module_name,
+                "group": _classify_import(node, module_name, local_roots),
+                "one_per_line": len(node.names) == 1,
+                "wildcard": any(alias.name == "*" for alias in node.names),
+                "relative": isinstance(node, ast.ImportFrom) and node.level > 0,
+            }
+        )
+
+    return sorted(imports, key=lambda item: (int(item["line"]), str(item["name"])))
+
+
+def _imported_module_name(node: ast.Import | ast.ImportFrom) -> str:
+    if isinstance(node, ast.Import):
+        return node.names[0].name
+    dots = "." * node.level
+    return f"{dots}{node.module or ''}"
+
+
+def _classify_import(
+    node: ast.Import | ast.ImportFrom,
+    module_name: str,
+    local_roots: set[str],
+) -> str:
+    if isinstance(node, ast.ImportFrom) and node.level > 0:
+        return "local"
+
+    root = module_name.split(".", 1)[0]
+    if root in local_roots:
+        return "local"
+    if root in sys.stdlib_module_names or root == "__future__":
+        return "stdlib"
+    return "third_party"
+
+
+def _groups_are_ordered(imports: list[dict[str, object]]) -> bool:
+    ranks = [GROUP_ORDER[str(item["group"])] for item in imports]
+    return ranks == sorted(ranks)
+
+
+def _imports_are_alphabetized(imports: list[dict[str, object]]) -> bool:
+    by_group: dict[str, list[str]] = defaultdict(list)
+    for item in imports:
+        by_group[str(item["group"])].append(str(item["name"]).lstrip("."))
+
+    return all(names == sorted(names, key=str.lower) for names in by_group.values())

--- a/src/akira/fingerprint/extractors/imports.py
+++ b/src/akira/fingerprint/extractors/imports.py
@@ -32,9 +32,9 @@ def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
     no_relative = sum(1 for item in all_imports if not item["relative"])
     group_sequences = [tuple(dict.fromkeys(item["group"] for item in imports)) for imports in non_empty]
     sequence_counts = Counter(group_sequences)
-    dominant_sequence, dominant_count = sorted(
+    dominant_sequence = sorted(
         sequence_counts.items(), key=lambda item: (-item[1], item[0])
-    )[0]
+    )[0][0]
 
     return (
         make_pattern(

--- a/src/akira/fingerprint/extractors/naming.py
+++ b/src/akira/fingerprint/extractors/naming.py
@@ -1,0 +1,173 @@
+"""Naming convention extractor."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+
+from akira.fingerprint.extractors._common import (
+    BOOLEAN_PREFIXES,
+    PASCAL_CASE_RE,
+    SNAKE_CASE_RE,
+    UPPER_SNAKE_CASE_RE,
+    make_pattern,
+    modal_pattern,
+)
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract naming conventions for common Python symbols."""
+    names: dict[str, list[str]] = {
+        "functions": [],
+        "variables": [],
+        "classes": [],
+        "constants": [],
+        "private_helpers": [],
+        "boolean_prefixes": [],
+    }
+
+    for source in analysis.parsed_files:
+        if source.tree is None:
+            continue
+        module = source.tree
+        assert isinstance(module, ast.Module)
+
+        for node in ast.walk(module):
+            if isinstance(node, ast.ClassDef):
+                names["classes"].append(node.name)
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                names["functions"].append(node.name)
+                if node.name.startswith("_") and not node.name.startswith("__"):
+                    names["private_helpers"].append(node.name)
+                names["variables"].extend(arg.arg for arg in node.args.args)
+                names["variables"].extend(arg.arg for arg in node.args.kwonlyargs)
+            elif isinstance(node, ast.Assign | ast.AnnAssign):
+                targets = _assignment_targets(node)
+                for target in targets:
+                    if _is_module_level_constant(module, node, target):
+                        names["constants"].append(target)
+                    else:
+                        names["variables"].append(target)
+                    if _looks_boolean(node, target):
+                        names["boolean_prefixes"].append(target)
+            elif isinstance(node, ast.For | ast.AsyncFor | ast.comprehension):
+                names["variables"].extend(_target_names(node.target))
+
+    patterns: list[StylePattern] = []
+    patterns.extend(_convention_pattern("functions", names["functions"]))
+    patterns.extend(_convention_pattern("variables", names["variables"]))
+    patterns.extend(_convention_pattern("classes", names["classes"]))
+    patterns.extend(_convention_pattern("constants", names["constants"]))
+    patterns.extend(_private_helper_pattern(names["private_helpers"]))
+    patterns.extend(_boolean_prefix_pattern(names["boolean_prefixes"]))
+    return tuple(patterns)
+
+
+def _convention_pattern(category: str, values: list[str]) -> tuple[StylePattern, ...]:
+    if not values:
+        return ()
+
+    conventions = [_classify_name(value, category) for value in values]
+    convention, share, samples = modal_pattern(conventions)
+    return (
+        make_pattern(
+            dimension="naming",
+            name=category,
+            value=convention,
+            confidence=share,
+            samples=samples,
+            description=f"Dominant naming convention for {category.replace('_', ' ')}.",
+            evidence={"distribution": dict(sorted(Counter(conventions).items()))},
+        ),
+    )
+
+
+def _private_helper_pattern(values: list[str]) -> tuple[StylePattern, ...]:
+    if not values:
+        return ()
+
+    single_underscore = sum(
+        1 for value in values if value.startswith("_") and not value.startswith("__")
+    )
+    return (
+        make_pattern(
+            dimension="naming",
+            name="private_helpers",
+            value="single_leading_underscore",
+            confidence=single_underscore / len(values),
+            samples=len(values),
+            description="Private helper names use a single leading underscore.",
+            evidence={"examples": values[:5]},
+        ),
+    )
+
+
+def _boolean_prefix_pattern(values: list[str]) -> tuple[StylePattern, ...]:
+    if not values:
+        return ()
+
+    prefixed = [value for value in values if value.startswith(BOOLEAN_PREFIXES)]
+    prefixes = [value.split("_", 1)[0] + "_" for value in prefixed]
+    return (
+        make_pattern(
+            dimension="naming",
+            name="boolean_prefixes",
+            value=tuple(sorted(set(prefixes))),
+            confidence=len(prefixed) / len(values),
+            samples=len(values),
+            description="Boolean-like names use readable predicate prefixes.",
+            evidence={"observed": values[:10]},
+        ),
+    )
+
+
+def _classify_name(name: str, category: str) -> str:
+    if category == "classes" and PASCAL_CASE_RE.match(name):
+        return "PascalCase"
+    if category == "constants" and UPPER_SNAKE_CASE_RE.match(name):
+        return "UPPER_SNAKE_CASE"
+    if SNAKE_CASE_RE.match(name):
+        return "snake_case"
+    if PASCAL_CASE_RE.match(name):
+        return "PascalCase"
+    if UPPER_SNAKE_CASE_RE.match(name):
+        return "UPPER_SNAKE_CASE"
+    if "_" not in name and any(char.isupper() for char in name[1:]):
+        return "camelCase"
+    return "mixed_or_other"
+
+
+def _assignment_targets(node: ast.Assign | ast.AnnAssign) -> list[str]:
+    if isinstance(node, ast.AnnAssign):
+        return _target_names(node.target)
+
+    names: list[str] = []
+    for target in node.targets:
+        names.extend(_target_names(target))
+    return names
+
+
+def _target_names(target: ast.AST) -> list[str]:
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Tuple | ast.List):
+        names: list[str] = []
+        for element in target.elts:
+            names.extend(_target_names(element))
+        return names
+    return []
+
+
+def _is_module_level_constant(module: ast.Module, node: ast.AST, name: str) -> bool:
+    return node in module.body and UPPER_SNAKE_CASE_RE.match(name) is not None
+
+
+def _looks_boolean(node: ast.Assign | ast.AnnAssign, name: str) -> bool:
+    value = getattr(node, "value", None)
+    annotation = getattr(node, "annotation", None)
+    if isinstance(value, ast.Constant) and isinstance(value.value, bool):
+        return True
+    if isinstance(annotation, ast.Name) and annotation.id == "bool":
+        return True
+    return name.startswith(BOOLEAN_PREFIXES)

--- a/src/akira/fingerprint/extractors/organization.py
+++ b/src/akira/fingerprint/extractors/organization.py
@@ -209,11 +209,13 @@ def _is_main_block(node: ast.stmt) -> bool:
     if not isinstance(compare, ast.Compare):
         return False
     left_is_name = isinstance(compare.left, ast.Name) and compare.left.id == "__name__"
-    has_main = any(
-        isinstance(comparator, ast.Constant) and comparator.value == "__main__"
-        for comparator in compare.comparators
+    is_eq = len(compare.ops) == 1 and isinstance(compare.ops[0], ast.Eq)
+    has_main = (
+        len(compare.comparators) == 1
+        and isinstance(compare.comparators[0], ast.Constant)
+        and compare.comparators[0].value == "__main__"
     )
-    return left_is_name and has_main
+    return left_is_name and is_eq and has_main
 
 
 def _is_type_container(node: ast.ClassDef) -> bool:

--- a/src/akira/fingerprint/extractors/organization.py
+++ b/src/akira/fingerprint/extractors/organization.py
@@ -1,0 +1,246 @@
+"""Module and class organization extractor."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+
+from akira.fingerprint.extractors._common import make_pattern, modal_pattern
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+MODULE_ORDER = {
+    "module_docstring": 0,
+    "imports": 1,
+    "constants": 2,
+    "types": 3,
+    "private_helpers": 4,
+    "public_functions": 5,
+    "classes": 6,
+    "main_block": 7,
+}
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract module ordering, helper placement, class order, and main blocks."""
+    module_sequences: list[tuple[str, ...]] = []
+    ordered_modules = 0
+    private_before_public = 0
+    modules_with_helpers = 0
+    class_orders: list[tuple[str, ...]] = []
+    main_blocks_at_end = 0
+    main_blocks = 0
+
+    for source in analysis.parsed_files:
+        if source.tree is None:
+            continue
+        module = source.tree
+        assert isinstance(module, ast.Module)
+
+        sequence = _module_sequence(module)
+        if sequence:
+            module_sequences.append(sequence)
+            if _is_ordered(sequence, MODULE_ORDER):
+                ordered_modules += 1
+
+        helper_result = _helper_placement(module)
+        if helper_result is not None:
+            modules_with_helpers += 1
+            if helper_result:
+                private_before_public += 1
+
+        for node in module.body:
+            if isinstance(node, ast.ClassDef):
+                class_sequence = _class_member_sequence(node)
+                if class_sequence:
+                    class_orders.append(class_sequence)
+
+        main_index = _main_block_index(module)
+        if main_index is not None:
+            main_blocks += 1
+            if main_index == len(module.body) - 1:
+                main_blocks_at_end += 1
+
+    patterns: list[StylePattern] = []
+    patterns.extend(_module_order_pattern(module_sequences, ordered_modules))
+    patterns.extend(_helper_placement_pattern(private_before_public, modules_with_helpers))
+    patterns.extend(_class_member_order_pattern(class_orders))
+    patterns.extend(_main_block_pattern(main_blocks_at_end, main_blocks))
+    return tuple(patterns)
+
+
+def _module_order_pattern(
+    sequences: list[tuple[str, ...]],
+    ordered_modules: int,
+) -> tuple[StylePattern, ...]:
+    sequence, _, samples = modal_pattern(sequences)
+    if sequence is None:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="organization",
+            name="module_order",
+            value=sequence,
+            confidence=ordered_modules / len(sequences),
+            samples=samples,
+            description="Top-level module elements follow a stable structural order.",
+            evidence={
+                "sequences": {" > ".join(key): count for key, count in Counter(sequences).items()}
+            },
+        ),
+    )
+
+
+def _helper_placement_pattern(before: int, samples: int) -> tuple[StylePattern, ...]:
+    if not samples:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="organization",
+            name="helper_placement",
+            value="private_helpers_before_public_api",
+            confidence=before / samples,
+            samples=samples,
+            description="Private helper functions are placed before public functions.",
+            evidence={"matching_modules": before, "modules_with_helpers": samples},
+        ),
+    )
+
+
+def _class_member_order_pattern(sequences: list[tuple[str, ...]]) -> tuple[StylePattern, ...]:
+    sequence, share, samples = modal_pattern(sequences)
+    if sequence is None:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="organization",
+            name="class_member_order",
+            value=sequence,
+            confidence=share,
+            samples=samples,
+            description="Class members follow a repeatable constructor/public/private order.",
+            evidence={"distribution": {" > ".join(key): count for key, count in Counter(sequences).items()}},
+        ),
+    )
+
+
+def _main_block_pattern(at_end: int, samples: int) -> tuple[StylePattern, ...]:
+    if not samples:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="organization",
+            name="main_block",
+            value="at_module_end",
+            confidence=at_end / samples,
+            samples=samples,
+            description="if __name__ == '__main__' blocks are placed at module end.",
+            evidence={"main_blocks": samples, "at_end": at_end},
+        ),
+    )
+
+
+def _module_sequence(module: ast.Module) -> tuple[str, ...]:
+    categories = [_module_category(node) for node in module.body]
+    return tuple(dict.fromkeys(category for category in categories if category))
+
+
+def _module_category(node: ast.stmt) -> str | None:
+    if _is_docstring_expr(node):
+        return "module_docstring"
+    if isinstance(node, ast.Import | ast.ImportFrom):
+        return "imports"
+    if _is_main_block(node):
+        return "main_block"
+    if isinstance(node, ast.ClassDef):
+        return "types" if _is_type_container(node) else "classes"
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        return "private_helpers" if node.name.startswith("_") else "public_functions"
+    if isinstance(node, ast.Assign | ast.AnnAssign):
+        return "constants"
+    return None
+
+
+def _class_member_sequence(node: ast.ClassDef) -> tuple[str, ...]:
+    categories: list[str] = []
+    for child in node.body:
+        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            if child.name == "__init__":
+                categories.append("constructor")
+            elif child.name.startswith("_"):
+                categories.append("private_methods")
+            else:
+                categories.append("public_methods")
+        elif isinstance(child, ast.Assign | ast.AnnAssign):
+            categories.append("attributes")
+    return tuple(dict.fromkeys(categories))
+
+
+def _helper_placement(module: ast.Module) -> bool | None:
+    private_lines = [
+        node.lineno
+        for node in module.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name.startswith("_")
+    ]
+    public_lines = [
+        node.lineno
+        for node in module.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and not node.name.startswith("_")
+    ]
+    if not private_lines or not public_lines:
+        return None
+    return max(private_lines) < min(public_lines)
+
+
+def _main_block_index(module: ast.Module) -> int | None:
+    for index, node in enumerate(module.body):
+        if _is_main_block(node):
+            return index
+    return None
+
+
+def _is_main_block(node: ast.stmt) -> bool:
+    if not isinstance(node, ast.If):
+        return False
+    compare = node.test
+    if not isinstance(compare, ast.Compare):
+        return False
+    left_is_name = isinstance(compare.left, ast.Name) and compare.left.id == "__name__"
+    has_main = any(
+        isinstance(comparator, ast.Constant) and comparator.value == "__main__"
+        for comparator in compare.comparators
+    )
+    return left_is_name and has_main
+
+
+def _is_type_container(node: ast.ClassDef) -> bool:
+    base_names = {_base_name(base) for base in node.bases}
+    decorator_names = {_base_name(decorator) for decorator in node.decorator_list}
+    type_markers = {"dataclass", "TypedDict", "NamedTuple", "Protocol"}
+    return bool((base_names | decorator_names) & type_markers)
+
+
+def _base_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _base_name(node.func)
+    return ""
+
+
+def _is_docstring_expr(node: ast.stmt) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def _is_ordered(sequence: tuple[str, ...], order: dict[str, int]) -> bool:
+    ranks = [order[item] for item in sequence if item in order]
+    return ranks == sorted(ranks)

--- a/src/akira/fingerprint/extractors/spacing.py
+++ b/src/akira/fingerprint/extractors/spacing.py
@@ -1,0 +1,132 @@
+"""Spacing style extractor."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+
+from akira.fingerprint.extractors._common import (
+    blank_lines_before,
+    blank_lines_between,
+    make_pattern,
+    modal_pattern,
+)
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract blank-line and logical spacing preferences."""
+    top_level: list[int] = []
+    methods: list[int] = []
+    after_imports: list[int] = []
+    logical_blocks: list[int] = []
+
+    for source in analysis.parsed_files:
+        if source.tree is None:
+            continue
+
+        lines = source.text.splitlines()
+        module = source.tree
+        assert isinstance(module, ast.Module)
+
+        for node in module.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                top_level.append(blank_lines_before(lines, node.lineno))
+            if isinstance(node, ast.ClassDef):
+                class_methods = [
+                    child
+                    for child in node.body
+                    if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef)
+                ]
+                for child in class_methods[1:]:
+                    methods.append(blank_lines_before(lines, child.lineno))
+
+        import_gap = _blank_lines_after_import_section(module, lines)
+        if import_gap is not None:
+            after_imports.append(import_gap)
+
+        for node in ast.walk(module):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                for previous, current in zip(node.body, node.body[1:]):
+                    previous_end = getattr(previous, "end_lineno", previous.lineno)
+                    gap = blank_lines_between(lines, previous_end, current.lineno)
+                    if gap > 0:
+                        logical_blocks.append(gap)
+
+    patterns: list[StylePattern] = []
+    patterns.extend(
+        _dominant_blank_line_pattern(
+            name="top_level_definitions",
+            values=top_level,
+            description="Blank lines before top-level functions and classes.",
+        )
+    )
+    patterns.extend(
+        _dominant_blank_line_pattern(
+            name="methods",
+            values=methods,
+            description="Blank lines before methods inside classes.",
+        )
+    )
+    patterns.extend(
+        _dominant_blank_line_pattern(
+            name="after_imports",
+            values=after_imports,
+            description="Blank lines between the import section and the next statement.",
+        )
+    )
+    patterns.extend(
+        _dominant_blank_line_pattern(
+            name="logical_blocks",
+            values=logical_blocks,
+            description="Blank lines used between logical statement groups inside functions.",
+        )
+    )
+    return tuple(patterns)
+
+
+def _dominant_blank_line_pattern(
+    *,
+    name: str,
+    values: list[int],
+    description: str,
+) -> tuple[StylePattern, ...]:
+    value, share, samples = modal_pattern(values)
+    if value is None:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="spacing",
+            name=name,
+            value=value,
+            confidence=share,
+            samples=samples,
+            description=description,
+            evidence={"distribution": dict(sorted(Counter(values).items()))},
+        ),
+    )
+
+
+def _blank_lines_after_import_section(module: ast.Module, lines: list[str]) -> int | None:
+    import_nodes = [
+        node
+        for node in module.body
+        if isinstance(node, ast.Import | ast.ImportFrom)
+        or (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        )
+    ]
+    imports = [node for node in import_nodes if isinstance(node, ast.Import | ast.ImportFrom)]
+    if not imports:
+        return None
+
+    last_import = max(imports, key=lambda node: getattr(node, "end_lineno", node.lineno))
+    last_line = getattr(last_import, "end_lineno", last_import.lineno)
+    next_nodes = [node for node in module.body if node.lineno > last_line]
+    if not next_nodes:
+        return None
+
+    return blank_lines_between(lines, last_line, next_nodes[0].lineno)

--- a/src/akira/fingerprint/extractors/strings.py
+++ b/src/akira/fingerprint/extractors/strings.py
@@ -1,0 +1,160 @@
+"""String literal and interpolation style extractor."""
+
+from __future__ import annotations
+
+import ast
+import io
+import re
+import tokenize
+from collections import Counter
+
+from akira.fingerprint.extractors._common import make_pattern, modal_pattern
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+STRING_PREFIX_RE = re.compile(r"(?is)^[rubf]*")
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract quote, f-string, and multiline string preferences."""
+    quote_styles: list[str] = []
+    multiline_styles: list[str] = []
+    fstrings = 0
+    format_calls = 0
+    percent_formats = 0
+
+    for source in analysis.files:
+        file_strings = _string_tokens(source.text)
+        quote_styles.extend(item["quote"] for item in file_strings if item["quote"])
+        multiline_styles.extend(item["quote"] for item in file_strings if item["multiline"])
+
+    for source in analysis.parsed_files:
+        if source.tree is None:
+            continue
+        fstrings += sum(1 for node in ast.walk(source.tree) if isinstance(node, ast.JoinedStr))
+        format_calls += sum(1 for node in ast.walk(source.tree) if _is_format_call(node))
+        percent_formats += sum(1 for node in ast.walk(source.tree) if _is_percent_format(node))
+
+    patterns: list[StylePattern] = []
+    patterns.extend(_quote_style_pattern(quote_styles))
+    patterns.extend(_interpolation_pattern(fstrings, format_calls, percent_formats))
+    patterns.extend(_multiline_pattern(multiline_styles))
+    return tuple(patterns)
+
+
+def _quote_style_pattern(styles: list[str]) -> tuple[StylePattern, ...]:
+    style, share, samples = modal_pattern(styles)
+    if style is None:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="strings",
+            name="quote_style",
+            value=style,
+            confidence=share,
+            samples=samples,
+            description="Dominant quote character used for string literals.",
+            evidence={"distribution": dict(sorted(Counter(styles).items()))},
+        ),
+    )
+
+
+def _interpolation_pattern(
+    fstrings: int,
+    format_calls: int,
+    percent_formats: int,
+) -> tuple[StylePattern, ...]:
+    total = fstrings + format_calls + percent_formats
+    if not total:
+        return ()
+
+    counts = {
+        "f_strings": fstrings,
+        "format_calls": format_calls,
+        "percent_formatting": percent_formats,
+    }
+    value, count = sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0]
+    return (
+        make_pattern(
+            dimension="strings",
+            name="interpolation_style",
+            value=value,
+            confidence=count / total,
+            samples=total,
+            description="Dominant string interpolation technique.",
+            evidence=counts,
+        ),
+    )
+
+
+def _multiline_pattern(styles: list[str]) -> tuple[StylePattern, ...]:
+    style, share, samples = modal_pattern(styles)
+    if style is None:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="strings",
+            name="multiline_strings",
+            value=f"triple_{style}",
+            confidence=share,
+            samples=samples,
+            description="Dominant quote style for multiline string literals.",
+            evidence={"distribution": dict(sorted(Counter(styles).items()))},
+        ),
+    )
+
+
+def _string_tokens(text: str) -> list[dict[str, object]]:
+    strings: list[dict[str, object]] = []
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        for token in tokens:
+            if token.type != tokenize.STRING:
+                continue
+            strings.append(_classify_string_token(token.string))
+    except tokenize.TokenError:
+        return strings
+    return strings
+
+
+def _classify_string_token(token: str) -> dict[str, object]:
+    stripped = token.lstrip()
+    prefix = STRING_PREFIX_RE.match(stripped)
+    start = prefix.end() if prefix else 0
+    literal = stripped[start:]
+
+    if literal.startswith('"""'):
+        quote = "double"
+        multiline = True
+    elif literal.startswith("'''"):
+        quote = "single"
+        multiline = True
+    elif literal.startswith('"'):
+        quote = "double"
+        multiline = False
+    elif literal.startswith("'"):
+        quote = "single"
+        multiline = False
+    else:
+        quote = ""
+        multiline = False
+
+    return {"quote": quote, "multiline": multiline}
+
+
+def _is_format_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "format"
+    )
+
+
+def _is_percent_format(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Mod)
+        and isinstance(node.left, ast.Constant)
+        and isinstance(node.left.value, str)
+    )

--- a/src/akira/fingerprint/extractors/structure.py
+++ b/src/akira/fingerprint/extractors/structure.py
@@ -38,8 +38,14 @@ def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
     early_return_count = sum(1 for function in functions if _has_early_return(function))
     guard_count = sum(1 for function in functions if _has_guard_clause(function))
     nesting_depths = [_max_nesting_depth(function) for function in functions]
-    ternary_count = sum(
-        1 for function in functions for node in ast.walk(function) if isinstance(node, ast.IfExp)
+    ternary_counts = [
+        sum(1 for node in _walk_current_scope(function) if isinstance(node, ast.IfExp))
+        for function in functions
+    ]
+    ternary_count = sum(ternary_counts)
+    functions_with_ternary = sum(1 for count in ternary_counts if count > 0)
+    ternary_confidence = (
+        1.0 if functions_with_ternary == 0 else functions_with_ternary / len(functions)
     )
     lengths = [_function_length(function) for function in functions]
     dominant_depth, depth_share, depth_samples = modal_pattern(nesting_depths)
@@ -75,11 +81,14 @@ def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
         make_pattern(
             dimension="structure",
             name="ternary_usage",
-            value="uses_ternary" if ternary_count else "avoids_ternary",
-            confidence=1.0 if ternary_count == 0 else min(1.0, ternary_count / len(functions)),
+            value="uses_ternary" if functions_with_ternary else "avoids_ternary",
+            confidence=ternary_confidence,
             samples=len(functions),
             description="Conditional expressions are detected in function bodies.",
-            evidence={"ternary_expressions": ternary_count},
+            evidence={
+                "ternary_expressions": ternary_count,
+                "functions_with_ternary": functions_with_ternary,
+            },
         ),
         make_pattern(
             dimension="structure",
@@ -94,7 +103,7 @@ def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
 
 
 def _has_early_return(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    returns = [node for node in ast.walk(function) if isinstance(node, ast.Return)]
+    returns = [node for node in _walk_current_scope(function) if isinstance(node, ast.Return)]
     if not returns:
         return False
 
@@ -120,8 +129,26 @@ def _max_nesting_depth(function: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
 
 def _nesting_depth(node: ast.AST, depth: int) -> int:
     next_depth = depth + 1 if isinstance(node, BRANCH_NODES) else depth
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        return next_depth
     child_depths = [_nesting_depth(child, next_depth) for child in ast.iter_child_nodes(node)]
     return max([next_depth, *child_depths])
+
+
+def _walk_current_scope(function: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.AST]:
+    nodes: list[ast.AST] = []
+    for statement in function.body:
+        nodes.extend(_walk_without_nested_scopes(statement))
+    return nodes
+
+
+def _walk_without_nested_scopes(node: ast.AST) -> list[ast.AST]:
+    nodes = [node]
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        return nodes
+    for child in ast.iter_child_nodes(node):
+        nodes.extend(_walk_without_nested_scopes(child))
+    return nodes
 
 
 def _function_length(function: ast.FunctionDef | ast.AsyncFunctionDef) -> int:

--- a/src/akira/fingerprint/extractors/structure.py
+++ b/src/akira/fingerprint/extractors/structure.py
@@ -1,0 +1,138 @@
+"""Control-flow and function-shape extractor."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from statistics import median
+
+from akira.fingerprint.extractors._common import (
+    iter_function_defs,
+    make_pattern,
+    modal_pattern,
+)
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+BRANCH_NODES = (
+    ast.If,
+    ast.For,
+    ast.AsyncFor,
+    ast.While,
+    ast.Try,
+    ast.With,
+    ast.AsyncWith,
+    ast.Match,
+)
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract early returns, nesting, ternary usage, and function length."""
+    functions: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for source in analysis.parsed_files:
+        if source.tree is not None:
+            functions.extend(iter_function_defs(source.tree))
+
+    if not functions:
+        return ()
+
+    early_return_count = sum(1 for function in functions if _has_early_return(function))
+    guard_count = sum(1 for function in functions if _has_guard_clause(function))
+    nesting_depths = [_max_nesting_depth(function) for function in functions]
+    ternary_count = sum(
+        1 for function in functions for node in ast.walk(function) if isinstance(node, ast.IfExp)
+    )
+    lengths = [_function_length(function) for function in functions]
+    dominant_depth, depth_share, depth_samples = modal_pattern(nesting_depths)
+
+    return (
+        make_pattern(
+            dimension="structure",
+            name="early_returns",
+            value=_frequency_label(early_return_count, len(functions)),
+            confidence=early_return_count / len(functions),
+            samples=len(functions),
+            description="Functions use returns before the final statement.",
+            evidence={"functions_with_early_return": early_return_count},
+        ),
+        make_pattern(
+            dimension="structure",
+            name="guard_clauses",
+            value=_frequency_label(guard_count, len(functions)),
+            confidence=guard_count / len(functions),
+            samples=len(functions),
+            description="Functions use top-of-body guard clauses with return or raise.",
+            evidence={"functions_with_guard_clause": guard_count},
+        ),
+        make_pattern(
+            dimension="structure",
+            name="nesting_depth",
+            value=dominant_depth,
+            confidence=depth_share,
+            samples=depth_samples,
+            description="Dominant maximum control-flow nesting depth per function.",
+            evidence={"distribution": dict(sorted(Counter(nesting_depths).items()))},
+        ),
+        make_pattern(
+            dimension="structure",
+            name="ternary_usage",
+            value="uses_ternary" if ternary_count else "avoids_ternary",
+            confidence=1.0 if ternary_count == 0 else min(1.0, ternary_count / len(functions)),
+            samples=len(functions),
+            description="Conditional expressions are detected in function bodies.",
+            evidence={"ternary_expressions": ternary_count},
+        ),
+        make_pattern(
+            dimension="structure",
+            name="function_length",
+            value="under_30_lines" if median(lengths) <= 30 else "over_30_lines",
+            confidence=sum(1 for length in lengths if length <= 30) / len(lengths),
+            samples=len(lengths),
+            description="Function body length preference based on physical source lines.",
+            evidence={"median": median(lengths), "max": max(lengths)},
+        ),
+    )
+
+
+def _has_early_return(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    returns = [node for node in ast.walk(function) if isinstance(node, ast.Return)]
+    if not returns:
+        return False
+
+    final_statement = function.body[-1] if function.body else None
+    final_line = getattr(final_statement, "end_lineno", getattr(final_statement, "lineno", 0))
+    return any(getattr(node, "lineno", final_line) < final_line for node in returns)
+
+
+def _has_guard_clause(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for statement in function.body[:3]:
+        if isinstance(statement, ast.If) and _body_exits(statement.body):
+            return True
+    return False
+
+
+def _body_exits(body: list[ast.stmt]) -> bool:
+    return bool(body) and isinstance(body[-1], ast.Return | ast.Raise | ast.Continue | ast.Break)
+
+
+def _max_nesting_depth(function: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    return max((_nesting_depth(statement, 0) for statement in function.body), default=0)
+
+
+def _nesting_depth(node: ast.AST, depth: int) -> int:
+    next_depth = depth + 1 if isinstance(node, BRANCH_NODES) else depth
+    child_depths = [_nesting_depth(child, next_depth) for child in ast.iter_child_nodes(node)]
+    return max([next_depth, *child_depths])
+
+
+def _function_length(function: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    end_lineno = getattr(function, "end_lineno", function.lineno)
+    return max(1, end_lineno - function.lineno + 1)
+
+
+def _frequency_label(count: int, total: int) -> str:
+    share = count / total if total else 0.0
+    if share >= 0.6:
+        return "preferred"
+    if share > 0:
+        return "occasional"
+    return "rare"

--- a/src/akira/fingerprint/extractors/typing.py
+++ b/src/akira/fingerprint/extractors/typing.py
@@ -1,0 +1,214 @@
+"""Type hint style extractor."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+
+from akira.fingerprint.extractors._common import (
+    iter_function_defs,
+    make_pattern,
+    modal_pattern,
+)
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+
+COMPLEX_TYPING_NAMES = {
+    "Any",
+    "Callable",
+    "ClassVar",
+    "Final",
+    "Generic",
+    "Iterable",
+    "Iterator",
+    "Literal",
+    "Mapping",
+    "MutableMapping",
+    "NamedTuple",
+    "Protocol",
+    "Sequence",
+    "TypedDict",
+    "TypeVar",
+    "cast",
+    "overload",
+}
+
+
+def extract(analysis: FingerprintAnalysis) -> tuple[StylePattern, ...]:
+    """Extract type annotation coverage and annotation syntax preferences."""
+    functions: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    optional_styles: list[str] = []
+    typing_imports: list[str] = []
+
+    for source in analysis.parsed_files:
+        if source.tree is None:
+            continue
+
+        functions.extend(iter_function_defs(source.tree))
+        optional_styles.extend(_optional_styles(source.tree))
+        typing_imports.extend(_typing_imports(source.tree))
+
+    patterns: list[StylePattern] = []
+    patterns.extend(_signature_coverage_pattern(functions))
+    patterns.extend(_return_hint_pattern(functions))
+    patterns.extend(_optional_syntax_pattern(optional_styles))
+    patterns.extend(_complex_type_import_pattern(typing_imports))
+    return tuple(patterns)
+
+
+def _signature_coverage_pattern(
+    functions: list[ast.FunctionDef | ast.AsyncFunctionDef],
+) -> tuple[StylePattern, ...]:
+    if not functions:
+        return ()
+
+    fully_typed = sum(1 for function in functions if _has_full_signature(function))
+    share = fully_typed / len(functions)
+    if share >= 0.8:
+        value = "full_signature_hints"
+    elif share >= 0.35:
+        value = "partial_signature_hints"
+    else:
+        value = "minimal_signature_hints"
+
+    return (
+        make_pattern(
+            dimension="typing",
+            name="signature_coverage",
+            value=value,
+            confidence=share,
+            samples=len(functions),
+            description="Function signatures include argument and return type hints.",
+            evidence={"fully_typed": fully_typed, "functions": len(functions)},
+        ),
+    )
+
+
+def _return_hint_pattern(
+    functions: list[ast.FunctionDef | ast.AsyncFunctionDef],
+) -> tuple[StylePattern, ...]:
+    if not functions:
+        return ()
+
+    annotated = sum(1 for function in functions if function.returns is not None)
+    return (
+        make_pattern(
+            dimension="typing",
+            name="return_hints",
+            value="explicit_return_hints",
+            confidence=annotated / len(functions),
+            samples=len(functions),
+            description="Functions declare explicit return type hints.",
+            evidence={"annotated": annotated, "functions": len(functions)},
+        ),
+    )
+
+
+def _optional_syntax_pattern(styles: list[str]) -> tuple[StylePattern, ...]:
+    style, share, samples = modal_pattern(styles)
+    if style is None:
+        return ()
+
+    return (
+        make_pattern(
+            dimension="typing",
+            name="optional_syntax",
+            value=style,
+            confidence=share,
+            samples=samples,
+            description="Optional values use a consistent annotation syntax.",
+            evidence={"distribution": dict(sorted(Counter(styles).items()))},
+        ),
+    )
+
+
+def _complex_type_import_pattern(imports: list[str]) -> tuple[StylePattern, ...]:
+    if not imports:
+        return ()
+
+    complex_imports = [name for name in imports if name in COMPLEX_TYPING_NAMES]
+    return (
+        make_pattern(
+            dimension="typing",
+            name="complex_type_imports",
+            value=tuple(sorted(set(complex_imports))),
+            confidence=len(complex_imports) / len(imports),
+            samples=len(imports),
+            description="Complex typing helpers are imported explicitly from typing.",
+            evidence={"imports": dict(sorted(Counter(imports).items()))},
+        ),
+    )
+
+
+def _has_full_signature(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    args = [
+        *function.args.posonlyargs,
+        *function.args.args,
+        *function.args.kwonlyargs,
+    ]
+    required_args = [arg for arg in args if arg.arg not in {"self", "cls"}]
+    args_typed = all(arg.annotation is not None for arg in required_args)
+    return args_typed and function.returns is not None
+
+
+def _typing_imports(tree: ast.AST) -> list[str]:
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "typing":
+            imports.extend(alias.name for alias in node.names)
+    return imports
+
+
+def _optional_styles(tree: ast.AST) -> list[str]:
+    styles: list[str] = []
+    for node in ast.walk(tree):
+        annotation = _annotation_node(node)
+        if annotation is None:
+            continue
+        style = _classify_optional(annotation)
+        if style is not None:
+            styles.append(style)
+    return styles
+
+
+def _annotation_node(node: ast.AST) -> ast.AST | None:
+    if isinstance(node, ast.arg):
+        return node.annotation
+    if isinstance(node, ast.AnnAssign):
+        return node.annotation
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        return node.returns
+    return None
+
+
+def _classify_optional(annotation: ast.AST) -> str | None:
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        if _contains_none(annotation.left) or _contains_none(annotation.right):
+            return "pipe_union_none"
+    if isinstance(annotation, ast.Subscript):
+        name = _annotation_name(annotation.value)
+        if name == "Optional":
+            return "typing_optional"
+        if name == "Union" and _contains_none(annotation.slice):
+            return "typing_union_none"
+    return None
+
+
+def _contains_none(node: ast.AST) -> bool:
+    if isinstance(node, ast.Constant) and node.value is None:
+        return True
+    if isinstance(node, ast.Name) and node.id == "None":
+        return True
+    if isinstance(node, ast.Tuple):
+        return any(_contains_none(element) for element in node.elts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _contains_none(node.left) or _contains_none(node.right)
+    return False
+
+
+def _annotation_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""

--- a/src/akira/fingerprint/models.py
+++ b/src/akira/fingerprint/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -24,11 +24,25 @@ class SourceFile:
 
 
 @dataclass(frozen=True)
+class StylePattern:
+    """A structured style signal extracted from sampled source files."""
+
+    dimension: str
+    name: str
+    value: object
+    confidence: float
+    samples: int
+    description: str
+    evidence: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class FingerprintAnalysis:
     """The source sample that later fingerprint extractors consume."""
 
     project_root: Path
     files: tuple[SourceFile, ...]
+    patterns: tuple[StylePattern, ...] = ()
 
     @property
     def parsed_files(self) -> tuple[SourceFile, ...]:
@@ -39,3 +53,10 @@ class FingerprintAnalysis:
     def failed_files(self) -> tuple[SourceFile, ...]:
         """Return files that could not be parsed as Python."""
         return tuple(file for file in self.files if file.parse_error is not None)
+
+    @property
+    def confidence(self) -> float:
+        """Return the average confidence across extracted patterns."""
+        if not self.patterns:
+            return 0.0
+        return round(sum(pattern.confidence for pattern in self.patterns) / len(self.patterns), 2)

--- a/src/akira/fingerprint/models.py
+++ b/src/akira/fingerprint/models.py
@@ -59,4 +59,7 @@ class FingerprintAnalysis:
         """Return the average confidence across extracted patterns."""
         if not self.patterns:
             return 0.0
-        return round(sum(pattern.confidence for pattern in self.patterns) / len(self.patterns), 2)
+        return round(
+            sum(pattern.confidence for pattern in self.patterns) / len(self.patterns),
+            2,
+        )

--- a/src/akira/fingerprint/renderer.py
+++ b/src/akira/fingerprint/renderer.py
@@ -1,0 +1,212 @@
+"""Render fingerprint analysis into durable project artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, PackageLoader, StrictUndefined
+
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+
+
+@dataclass(frozen=True)
+class FingerprintLine:
+    """A readable fingerprint assertion derived from a style pattern."""
+
+    label: str
+    value: str
+    confidence: float
+    samples: int
+
+
+@dataclass(frozen=True)
+class FingerprintSection:
+    """A rendered fingerprint.md section."""
+
+    title: str
+    lines: tuple[FingerprintLine, ...]
+
+
+SECTION_ORDER = (
+    ("spacing", "Spacing", ("top_level_definitions", "methods", "logical_blocks", "after_imports")),
+    ("comments", "Comments", ("section_separators", "inline_comment_frequency", "language", "todo_format")),
+    ("structure", "Control Flow", ("early_returns", "guard_clauses", "nesting_depth", "ternary_usage")),
+    ("naming", "Naming", ("functions", "variables", "classes", "constants", "private_helpers", "boolean_prefixes")),
+    ("imports", "Imports", ("grouping_order", "alphabetical_order", "one_import_per_line", "wildcard_usage", "relative_imports")),
+    ("typing", "Type Hints", ("signature_coverage", "return_hints", "optional_syntax", "complex_type_imports")),
+    ("docstrings", "Docstrings", ("docstring_style", "public_docstrings", "class_docstrings", "private_docstring_behavior")),
+    ("error_handling", "Error Handling", ("exception_specificity", "logging_on_catch", "reraising")),
+    ("organization", "Organization", ("module_order", "helper_placement", "class_member_order", "main_block")),
+    ("strings", "Strings", ("quote_style", "interpolation_style", "multiline_strings")),
+    ("general", "General Patterns", ("function_length",)),
+)
+
+PATTERN_LABELS = {
+    "after_imports": "After imports section",
+    "alphabetical_order": "Alphabetical order",
+    "boolean_prefixes": "Boolean variables",
+    "class_docstrings": "Classes",
+    "class_member_order": "Class member order",
+    "classes": "Classes",
+    "complex_type_imports": "Complex type imports",
+    "docstring_style": "Style",
+    "early_returns": "Early returns",
+    "exception_specificity": "Exceptions",
+    "function_length": "Function length",
+    "functions": "Functions",
+    "grouping_order": "Order",
+    "guard_clauses": "Guard clauses",
+    "helper_placement": "Helper placement",
+    "inline_comment_frequency": "Inline comments",
+    "interpolation_style": "Interpolation",
+    "language": "Language",
+    "logging_on_catch": "Logging on catch",
+    "logical_blocks": "Inside functions",
+    "main_block": "Main block",
+    "methods": "Between methods",
+    "module_order": "Module order",
+    "multiline_strings": "Multi-line strings",
+    "nesting_depth": "Max nesting",
+    "one_import_per_line": "Style",
+    "optional_syntax": "Optional style",
+    "private_docstring_behavior": "Private methods",
+    "private_helpers": "Private helpers",
+    "public_docstrings": "Public functions",
+    "quote_style": "Quotes",
+    "relative_imports": "Relative imports",
+    "reraising": "Re-raising",
+    "return_hints": "Return types",
+    "section_separators": "Section separators",
+    "signature_coverage": "Coverage",
+    "ternary_usage": "Ternary",
+    "todo_format": "TODO format",
+    "top_level_definitions": "Between top-level definitions",
+    "variables": "Variables",
+    "wildcard_usage": "Wildcard imports",
+}
+
+VALUE_LABELS = {
+    "avoid_relative_imports": "Avoid relative imports",
+    "avoid_wildcards": "Avoid wildcard imports",
+    "avoids_ternary": "Avoids ternary expressions",
+    "double": 'Double quotes `"`',
+    "documented": "Documented",
+    "f_strings": "f-strings",
+    "full_signature_hints": "Full function signature hints",
+    "google": "Google style",
+    "hash_dash_section_separator": "`# --- Section ---`",
+    "mixed_or_other": "Mixed or other",
+    "low": "Low",
+    "omit_private_docstrings": "Omit private docstrings",
+    "PascalCase": "PascalCase",
+    "pipe_union_none": "`X | None`",
+    "preferred": "Preferred",
+    "present": "Present",
+    "rare": "Rare",
+    "single": "Single quotes `'`",
+    "single_leading_underscore": "Single leading underscore",
+    "snake_case": "snake_case",
+    "triple_double": 'Triple double quotes `"""`',
+    "under_30_lines": "Prefers functions under 30 lines",
+    "UPPER_SNAKE_CASE": "UPPER_SNAKE_CASE",
+    "uses_ternary": "Uses ternary expressions",
+}
+
+
+def render_fingerprint_markdown(
+    analysis: FingerprintAnalysis,
+    *,
+    generated_at: datetime | None = None,
+    sample_size: int | None = None,
+) -> str:
+    """Render fingerprint.md content for a fingerprint analysis."""
+    timestamp = generated_at or datetime.now(timezone.utc)
+    env = Environment(
+        loader=PackageLoader("akira.fingerprint", "templates"),
+        autoescape=False,
+        keep_trailing_newline=True,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        undefined=StrictUndefined,
+    )
+    template = env.get_template("fingerprint.md.j2")
+
+    return template.render(
+        generated_at=timestamp.replace(microsecond=0).isoformat(),
+        sample_size=sample_size if sample_size is not None else len(analysis.files),
+        files_analyzed=tuple(file.relative_path.as_posix() for file in analysis.files),
+        confidence=analysis.confidence,
+        sections=build_fingerprint_sections(analysis.patterns),
+    )
+
+
+def write_fingerprint_markdown(
+    output_dir: Path,
+    analysis: FingerprintAnalysis,
+    *,
+    sample_size: int | None = None,
+) -> Path:
+    """Create the output directory and write fingerprint.md into it."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "fingerprint.md"
+    path.write_text(
+        render_fingerprint_markdown(analysis, sample_size=sample_size),
+        encoding="utf-8",
+    )
+    return path
+
+
+def build_fingerprint_sections(
+    patterns: tuple[StylePattern, ...],
+) -> tuple[FingerprintSection, ...]:
+    """Build all v1.0 fingerprint sections in a stable order."""
+    by_dimension_and_name = {
+        (pattern.dimension, pattern.name): pattern for pattern in patterns
+    }
+    sections: list[FingerprintSection] = []
+
+    for dimension, title, names in SECTION_ORDER:
+        lines: list[FingerprintLine] = []
+        for name in names:
+            pattern = by_dimension_and_name.get((dimension, name))
+            if pattern is None and dimension == "general":
+                pattern = by_dimension_and_name.get(("structure", name))
+            if pattern is None:
+                continue
+            lines.append(_line_for_pattern(pattern))
+        sections.append(FingerprintSection(title=title, lines=tuple(lines)))
+
+    return tuple(sections)
+
+
+def _line_for_pattern(pattern: StylePattern) -> FingerprintLine:
+    return FingerprintLine(
+        label=PATTERN_LABELS.get(pattern.name, _humanize(pattern.name)),
+        value=_format_value(pattern.value),
+        confidence=pattern.confidence,
+        samples=pattern.samples,
+    )
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, tuple):
+        return " -> ".join(_format_value(item) for item in value)
+    if isinstance(value, list):
+        return ", ".join(_format_value(item) for item in value)
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, int):
+        noun = "blank line" if value == 1 else "blank lines"
+        return f"{value} {noun}"
+    if isinstance(value, float):
+        return f"{value:.2f}"
+
+    text = str(value)
+    return VALUE_LABELS.get(text, _humanize(text))
+
+
+def _humanize(value: str) -> str:
+    return value.replace("_", " ").replace("-", " ").title()

--- a/src/akira/fingerprint/renderer.py
+++ b/src/akira/fingerprint/renderer.py
@@ -110,11 +110,14 @@ VALUE_LABELS = {
     "single": "Single quotes `'`",
     "single_leading_underscore": "Single leading underscore",
     "sparse": "Sparse",
+    "specific_exceptions": "Specific exceptions",
     "snake_case": "snake_case",
     "triple_double": 'Triple double quotes `"""`',
     "under_30_lines": "Prefers functions under 30 lines",
     "UPPER_SNAKE_CASE": "UPPER_SNAKE_CASE",
     "uses_ternary": "Uses ternary expressions",
+    "logs_caught_exceptions": "Logs caught exceptions",
+    "reraises_after_catch": "Re-raises after catch",
 }
 
 

--- a/src/akira/fingerprint/renderer.py
+++ b/src/akira/fingerprint/renderer.py
@@ -205,10 +205,15 @@ def _format_value(pattern: StylePattern) -> str:
 
 
 def _format_raw_value(value: Any) -> str:
+    return format_fingerprint_value(value)
+
+
+def format_fingerprint_value(value: Any) -> str:
+    """Format a structured fingerprint value for human-readable Markdown."""
     if isinstance(value, tuple):
-        return " -> ".join(_format_raw_value(item) for item in value)
+        return " -> ".join(format_fingerprint_value(item) for item in value)
     if isinstance(value, list):
-        return ", ".join(_format_raw_value(item) for item in value)
+        return ", ".join(format_fingerprint_value(item) for item in value)
     if isinstance(value, bool):
         return "yes" if value else "no"
     if isinstance(value, int):

--- a/src/akira/fingerprint/renderer.py
+++ b/src/akira/fingerprint/renderer.py
@@ -37,7 +37,7 @@ SECTION_ORDER = (
     ("naming", "Naming", ("functions", "variables", "classes", "constants", "private_helpers", "boolean_prefixes")),
     ("imports", "Imports", ("grouping_order", "alphabetical_order", "one_import_per_line", "wildcard_usage", "relative_imports")),
     ("typing", "Type Hints", ("signature_coverage", "return_hints", "optional_syntax", "complex_type_imports")),
-    ("docstrings", "Docstrings", ("docstring_style", "public_docstrings", "class_docstrings", "private_docstring_behavior")),
+    ("docstrings", "Docstrings", ("docstring_style", "public_docstrings", "class_docstrings", "function_docstrings", "private_docstring_behavior")),
     ("error_handling", "Error Handling", ("exception_specificity", "logging_on_catch", "reraising")),
     ("organization", "Organization", ("module_order", "helper_placement", "class_member_order", "main_block")),
     ("strings", "Strings", ("quote_style", "interpolation_style", "multiline_strings")),
@@ -56,6 +56,7 @@ PATTERN_LABELS = {
     "early_returns": "Early returns",
     "exception_specificity": "Exceptions",
     "function_length": "Function length",
+    "function_docstrings": "Functions",
     "functions": "Functions",
     "grouping_order": "Order",
     "guard_clauses": "Guard clauses",
@@ -108,6 +109,7 @@ VALUE_LABELS = {
     "rare": "Rare",
     "single": "Single quotes `'`",
     "single_leading_underscore": "Single leading underscore",
+    "sparse": "Sparse",
     "snake_case": "snake_case",
     "triple_double": 'Triple double quotes `"""`',
     "under_30_lines": "Prefers functions under 30 lines",
@@ -184,29 +186,39 @@ def build_fingerprint_sections(
 
 def _line_for_pattern(pattern: StylePattern) -> FingerprintLine:
     return FingerprintLine(
-        label=PATTERN_LABELS.get(pattern.name, _humanize(pattern.name)),
-        value=_format_value(pattern.value),
+        label=PATTERN_LABELS.get(pattern.name, _humanize_label(pattern.name)),
+        value=_format_value(pattern),
         confidence=pattern.confidence,
         samples=pattern.samples,
     )
 
 
-def _format_value(value: Any) -> str:
+def _format_value(pattern: StylePattern) -> str:
+    if isinstance(pattern.value, int) and pattern.dimension == "spacing":
+        noun = "blank line" if pattern.value == 1 else "blank lines"
+        return f"{pattern.value} {noun}"
+    if pattern.name == "nesting_depth" and isinstance(pattern.value, int):
+        noun = "level" if pattern.value == 1 else "levels"
+        return f"{pattern.value} {noun}"
+
+    return _format_raw_value(pattern.value)
+
+
+def _format_raw_value(value: Any) -> str:
     if isinstance(value, tuple):
-        return " -> ".join(_format_value(item) for item in value)
+        return " -> ".join(_format_raw_value(item) for item in value)
     if isinstance(value, list):
-        return ", ".join(_format_value(item) for item in value)
+        return ", ".join(_format_raw_value(item) for item in value)
     if isinstance(value, bool):
         return "yes" if value else "no"
     if isinstance(value, int):
-        noun = "blank line" if value == 1 else "blank lines"
-        return f"{value} {noun}"
+        return str(value)
     if isinstance(value, float):
         return f"{value:.2f}"
 
     text = str(value)
-    return VALUE_LABELS.get(text, _humanize(text))
+    return VALUE_LABELS.get(text, text)
 
 
-def _humanize(value: str) -> str:
+def _humanize_label(value: str) -> str:
     return value.replace("_", " ").replace("-", " ").title()

--- a/src/akira/fingerprint/templates/fingerprint.md.j2
+++ b/src/akira/fingerprint/templates/fingerprint.md.j2
@@ -1,10 +1,14 @@
 ---
 generated_at: {{ generated_at | tojson }}
 sample_size: {{ sample_size }}
+{% if files_analyzed %}
 files_analyzed:
 {% for file in files_analyzed %}
   - {{ file | tojson }}
 {% endfor %}
+{% else %}
+files_analyzed: []
+{% endif %}
 confidence: {{ "%.2f"|format(confidence) }}
 ---
 

--- a/src/akira/fingerprint/templates/fingerprint.md.j2
+++ b/src/akira/fingerprint/templates/fingerprint.md.j2
@@ -1,0 +1,23 @@
+---
+generated_at: {{ generated_at | tojson }}
+sample_size: {{ sample_size }}
+files_analyzed:
+{% for file in files_analyzed %}
+  - {{ file | tojson }}
+{% endfor %}
+confidence: {{ "%.2f"|format(confidence) }}
+---
+
+# Developer Fingerprint
+
+{% for section in sections %}
+## {{ section.title }}
+{% if section.lines %}
+{% for line in section.lines %}
+- **{{ line.label }}**: {{ line.value }} (confidence {{ "%.2f"|format(line.confidence) }}, samples {{ line.samples }})
+{% endfor %}
+{% else %}
+- No stable pattern detected in the current sample.
+{% endif %}
+
+{% endfor %}

--- a/src/akira/skills/generator.py
+++ b/src/akira/skills/generator.py
@@ -10,6 +10,8 @@ from jinja2 import Environment, PackageLoader, StrictUndefined
 
 from akira.detect.categories import normalize_skill_category
 from akira.detect.models import StackInfo, ToolInfo
+from akira.fingerprint import fingerprint_project, format_fingerprint_value
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
 
 
 @dataclass(frozen=True)
@@ -152,7 +154,13 @@ class SkillGenerator:
             undefined=StrictUndefined,
         )
 
-    def generate(self, stack: StackInfo, output_dir: Path) -> tuple[GeneratedSkill, ...]:
+    def generate(
+        self,
+        stack: StackInfo,
+        output_dir: Path,
+        *,
+        fingerprint: FingerprintAnalysis | None = None,
+    ) -> tuple[GeneratedSkill, ...]:
         """Generate the Akira router and Python skills under output_dir/skills."""
         skills_dir = output_dir / "skills"
         python_dir = output_dir / "skills" / "python"
@@ -161,11 +169,16 @@ class SkillGenerator:
 
         selected = self.select_templates(stack)
         self._remove_stale_skills(python_dir, selected)
+        fingerprint_path = output_dir / "fingerprint.md"
+        fingerprint_exists = fingerprint is not None or fingerprint_path.exists()
+        if fingerprint is None and fingerprint_path.exists():
+            fingerprint = fingerprint_project(stack.project_root)
 
         context = build_template_context(
             stack,
             selected,
-            fingerprint_exists=(output_dir / "fingerprint.md").exists(),
+            fingerprint_exists=fingerprint_exists,
+            fingerprint=fingerprint,
         )
         generated = [
             self._render_to_file(
@@ -240,15 +253,21 @@ class SkillGenerator:
         return GeneratedSkill(path=output_path, template_path=template_path)
 
 
-def generate_skills(stack: StackInfo, output_dir: Path) -> tuple[GeneratedSkill, ...]:
+def generate_skills(
+    stack: StackInfo,
+    output_dir: Path,
+    *,
+    fingerprint: FingerprintAnalysis | None = None,
+) -> tuple[GeneratedSkill, ...]:
     """Generate Akira skills for a detected stack."""
-    return SkillGenerator().generate(stack, output_dir)
+    return SkillGenerator().generate(stack, output_dir, fingerprint=fingerprint)
 
 
 def build_template_context(
     stack: StackInfo,
     selected: tuple[SkillTemplate, ...] = (),
     fingerprint_exists: bool = False,
+    fingerprint: FingerprintAnalysis | None = None,
 ) -> dict[str, Any]:
     """Build the shared Jinja context for all skill templates."""
     tools = {tool.name: tool for category in stack.categories for tool in category.tools}
@@ -263,6 +282,7 @@ def build_template_context(
         "metadata": _merged_metadata(stack),
         "active_skills": active_skills,
         "fingerprint_exists": fingerprint_exists,
+        "fingerprint_core_rules": select_fingerprint_core_rules(fingerprint),
         "python_version": _version(tools, "python"),
         "package_manager": _first_tool_name(stack, "package_manager"),
         "root_active_skills": _root_active_skills(active_skills),
@@ -279,6 +299,107 @@ def build_template_context(
     context.update(_infra_context(stack, tools))
     context.update(_ci_context(stack))
     return {key: value for key, value in context.items() if value is not None}
+
+
+def select_fingerprint_core_rules(
+    fingerprint: FingerprintAnalysis | None,
+    *,
+    limit: int = 5,
+    minimum_confidence: float = 0.7,
+) -> tuple[str, ...]:
+    """Select concise router rules from high-confidence fingerprint patterns."""
+    if fingerprint is None:
+        return ()
+
+    by_key = {
+        (pattern.dimension, pattern.name): pattern
+        for pattern in fingerprint.patterns
+        if pattern.confidence >= minimum_confidence and pattern.samples > 0
+    }
+    rules: list[str] = []
+
+    for dimension, name in _CORE_RULE_PRIORITY:
+        pattern = by_key.get((dimension, name))
+        if pattern is None:
+            continue
+        rule = _core_rule_for_pattern(pattern)
+        if rule and rule not in rules:
+            rules.append(rule)
+        if len(rules) >= limit:
+            break
+
+    return tuple(rules)
+
+
+_CORE_RULE_PRIORITY = (
+    ("structure", "early_returns"),
+    ("structure", "guard_clauses"),
+    ("comments", "section_separators"),
+    ("comments", "inline_comment_frequency"),
+    ("spacing", "logical_blocks"),
+    ("typing", "signature_coverage"),
+    ("typing", "optional_syntax"),
+    ("structure", "nesting_depth"),
+    ("imports", "grouping_order"),
+    ("imports", "relative_imports"),
+    ("imports", "wildcard_usage"),
+    ("docstrings", "docstring_style"),
+    ("docstrings", "public_docstrings"),
+    ("docstrings", "private_docstring_behavior"),
+    ("strings", "quote_style"),
+    ("strings", "interpolation_style"),
+    ("structure", "function_length"),
+)
+
+
+def _core_rule_for_pattern(pattern: StylePattern) -> str | None:
+    key = (pattern.dimension, pattern.name)
+    value = pattern.value
+
+    if key == ("structure", "early_returns") and value == "preferred":
+        return "Prefer early returns over deeply nested branches."
+    if key == ("structure", "guard_clauses") and value == "preferred":
+        return "Put guard clauses near the top of functions."
+    if key == ("structure", "nesting_depth") and isinstance(value, int):
+        return f"Keep control-flow nesting to {value} {_plural('level', value)} or less."
+    if key == ("comments", "section_separators"):
+        return f"Use {format_fingerprint_value(value)} comments as section separators."
+    if key == ("comments", "inline_comment_frequency") and value in {"low", "rare"}:
+        return "Keep inline comments rare; prefer self-documenting code."
+    if key == ("spacing", "logical_blocks") and isinstance(value, int):
+        return (
+            f"Use {value} {_plural('blank line', value)} between logical blocks "
+            "inside functions."
+        )
+    if key == ("typing", "signature_coverage") and value == "full_signature_hints":
+        return "Use full type hints on function signatures."
+    if key == ("typing", "optional_syntax"):
+        return f"Use {format_fingerprint_value(value)} syntax for optional values."
+    if key == ("imports", "grouping_order"):
+        return f"Keep imports grouped in this order: {format_fingerprint_value(value)}."
+    if key == ("imports", "relative_imports") and value == "avoid_relative_imports":
+        return "Prefer absolute imports over relative imports."
+    if key == ("imports", "wildcard_usage") and value == "avoid_wildcards":
+        return "Avoid wildcard imports."
+    if key == ("docstrings", "docstring_style"):
+        return f"Write {format_fingerprint_value(value)} docstrings."
+    if key == ("docstrings", "public_docstrings") and value == "documented":
+        return "Document public functions and classes."
+    if key == ("docstrings", "private_docstring_behavior") and value == "omit_private_docstrings":
+        return "Omit docstrings on private helpers when names are descriptive."
+    if key == ("strings", "quote_style"):
+        return f"Use {format_fingerprint_value(value)} for string literals."
+    if key == ("strings", "interpolation_style") and value == "f_strings":
+        return "Prefer f-strings for string interpolation."
+    if key == ("structure", "function_length") and value == "under_30_lines":
+        return "Prefer functions under 30 lines."
+
+    return None
+
+
+def _plural(noun: str, count: int) -> str:
+    return noun if count == 1 else f"{noun}s"
+
 
 def _version_context(tools: Mapping[str, ToolInfo]) -> dict[str, str | None]:
     return {

--- a/src/akira/skills/generator.py
+++ b/src/akira/skills/generator.py
@@ -10,7 +10,7 @@ from jinja2 import Environment, PackageLoader, StrictUndefined
 
 from akira.detect.categories import normalize_skill_category
 from akira.detect.models import StackInfo, ToolInfo
-from akira.fingerprint import fingerprint_project, format_fingerprint_value
+from akira.fingerprint import format_fingerprint_value
 from akira.fingerprint.models import FingerprintAnalysis, StylePattern
 
 
@@ -170,14 +170,12 @@ class SkillGenerator:
         selected = self.select_templates(stack)
         self._remove_stale_skills(python_dir, selected)
         fingerprint_path = output_dir / "fingerprint.md"
-        fingerprint_exists = fingerprint is not None or fingerprint_path.exists()
-        if fingerprint is None and fingerprint_path.exists():
-            fingerprint = fingerprint_project(stack.project_root)
+        fingerprint_file_exists = fingerprint_path.exists()
 
         context = build_template_context(
             stack,
             selected,
-            fingerprint_exists=fingerprint_exists,
+            fingerprint_exists=fingerprint_file_exists,
             fingerprint=fingerprint,
         )
         generated = [
@@ -361,6 +359,8 @@ def _core_rule_for_pattern(pattern: StylePattern) -> str | None:
     if key == ("structure", "guard_clauses") and value == "preferred":
         return "Put guard clauses near the top of functions."
     if key == ("structure", "nesting_depth") and isinstance(value, int):
+        if value == 0:
+            return "Avoid nested control flow where possible."
         return f"Keep control-flow nesting to {value} {_plural('level', value)} or less."
     if key == ("comments", "section_separators"):
         return f"Use {format_fingerprint_value(value)} comments as section separators."

--- a/src/akira/skills/templates/base.md.j2
+++ b/src/akira/skills/templates/base.md.j2
@@ -34,10 +34,14 @@ Before writing code, consult:
 
 ## Core Rules From Fingerprint
 
-{% if fingerprint_exists | default(false) %}
-- Treat `fingerprint.md` as the source of truth for naming, spacing, imports,
-  typing, comments, docstrings, control flow, and organization.
-- Apply fingerprint rules before generic defaults when they conflict.
+{% if fingerprint_core_rules | default([]) %}
+{% for rule in fingerprint_core_rules %}
+- {{ rule }}
+{% endfor %}
+{% elif fingerprint_exists | default(false) %}
+- `fingerprint.md` exists, but Akira did not find enough high-confidence
+  structured rules for the router. Use it as the source of truth for detailed
+  style guidance.
 {% else %}
 - `fingerprint.md` may not exist yet. Until it is generated, preserve the
   conventions already present in nearby files.

--- a/tests/fixtures/style_projects/consistent/src/style_app/helpers.py
+++ b/tests/fixtures/style_projects/consistent/src/style_app/helpers.py
@@ -1,0 +1,22 @@
+"""Shared helpers for the consistent style fixture."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+DEFAULT_LABEL = "anonymous"
+
+
+def _normalize_name(name: str | None) -> str:
+    if name is None:
+        return DEFAULT_LABEL
+
+    return name.strip().lower()
+
+
+def build_tags(tags: Iterable[str] | None = None) -> list[str]:
+    if tags is None:
+        return []
+
+    return [tag.strip().lower() for tag in tags if tag.strip()]

--- a/tests/fixtures/style_projects/consistent/src/style_app/service.py
+++ b/tests/fixtures/style_projects/consistent/src/style_app/service.py
@@ -1,0 +1,76 @@
+"""User-facing service module for the consistent style fixture."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from style_app.helpers import _normalize_name, build_tags
+
+
+LOGGER = logging.getLogger(__name__)
+MAX_RETRIES = 3
+
+
+# --- Models ---
+@dataclass(frozen=True)
+class UserRecord:
+    """Stored user record.
+
+    Args:
+        name: Normalized user name.
+        tags: Normalized user tags.
+    """
+
+    name: str
+    tags: list[str]
+
+
+class UserService:
+    """Coordinate user record loading."""
+
+    retries = MAX_RETRIES
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+
+    def load_user(self, name: str | None, tags: list[str] | None = None) -> UserRecord:
+        """Load a normalized user record.
+
+        Args:
+            name: Raw user name.
+            tags: Optional raw tags.
+
+        Returns:
+            Normalized user record.
+        """
+        if not self.source:
+            raise HTTPException(status_code=500, detail="Missing source")
+
+        normalized_name = _normalize_name(name)
+        normalized_tags = build_tags(tags)
+
+        return UserRecord(name=normalized_name, tags=normalized_tags)
+
+    def _log_failure(self, path: str) -> None:
+        LOGGER.exception("Could not load %s", path)
+
+
+def render_user(record: UserRecord) -> str:
+    """Render a user record."""
+    if not record.tags:
+        return f"{record.name}: none"
+
+    return f"{record.name}: {', '.join(record.tags)}"
+
+
+def load_user_file(path: Path) -> str:
+    """Load a user fixture file."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        LOGGER.exception("Could not load %s", path)
+        raise

--- a/tests/fixtures/style_projects/mixed/src/style_app/helpers.py
+++ b/tests/fixtures/style_projects/mixed/src/style_app/helpers.py
@@ -1,0 +1,18 @@
+import sys, os
+from .service import UserRecord
+from fastapi import HTTPException
+
+DEFAULT_LABEL = 'anonymous'
+
+def normalizeName(name):
+    if name == None:
+        return DEFAULT_LABEL
+    else:
+        return name.strip().lower()
+
+def build_tags(tags = None):
+    result = []
+    for tag in tags or []:
+        if tag:
+            result.append(tag)
+    return result

--- a/tests/fixtures/style_projects/mixed/src/style_app/service.py
+++ b/tests/fixtures/style_projects/mixed/src/style_app/service.py
@@ -1,0 +1,26 @@
+from style_app.helpers import normalizeName
+import logging, json
+from fastapi import HTTPException
+
+LOGGER = logging.getLogger(__name__)
+maxRetries = 3
+
+class userService:
+    def __init__(self, source):
+        self.source = source
+    def loadUser(self, name, tags=None):
+        if self.source:
+            normalizedName = normalizeName(name)
+            if tags:
+                labels = []
+                for tag in tags:
+                    if tag:
+                        labels.append(tag)
+                return {"name": normalizedName, "tags": labels}
+            else:
+                return {"name": normalizedName, "tags": []}
+        raise HTTPException(status_code=500, detail='Missing source')
+
+def render_user(record):
+    # render value inline
+    return '{}: {}'.format(record["name"], record["tags"])

--- a/tests/fixtures/style_projects/with_syntax_error/src/style_app/broken.py
+++ b/tests/fixtures/style_projects/with_syntax_error/src/style_app/broken.py
@@ -1,0 +1,2 @@
+def broken_function(:
+    return "broken"

--- a/tests/fixtures/style_projects/with_syntax_error/src/style_app/valid.py
+++ b/tests/fixtures/style_projects/with_syntax_error/src/style_app/valid.py
@@ -1,0 +1,10 @@
+"""Valid file next to a syntax-error fixture."""
+
+from __future__ import annotations
+
+
+def load_value(value: str | None) -> str:
+    if value is None:
+        return "fallback"
+
+    return value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_fingerprint_help_documents_options() -> None:
     assert "--path" in result.stdout
     assert "--sample-size" in result.stdout
     assert "--exclude" in result.stdout
+    assert "--output" in result.stdout
 
 
 def test_fingerprint_command_collects_files_and_parse_failures(tmp_path: Path) -> None:
@@ -50,15 +51,61 @@ def test_fingerprint_command_collects_files_and_parse_failures(tmp_path: Path) -
     tests_dir.mkdir()
     (tests_dir / "test_valid.py").write_text("def test_valid():\n    pass\n", encoding="utf-8")
 
-    result = runner.invoke(
-        app,
-        ["fingerprint", "--path", str(tmp_path), "--exclude", "tests/"],
-    )
+    with runner.isolated_filesystem():
+        fingerprint_path = Path.cwd() / DEFAULT_OUTPUT_DIR / "fingerprint.md"
+        result = runner.invoke(
+            app,
+            ["fingerprint", "--path", str(tmp_path), "--exclude", "tests/"],
+        )
+        fingerprint_exists = fingerprint_path.exists()
 
     assert result.exit_code == 0
+    assert fingerprint_exists
     assert "Files analyzed: 2" in result.stdout
     assert "Parsed: 1" in result.stdout
     assert "Parse failures: 1" in result.stdout
+    assert f"Wrote: {fingerprint_path}" in result.stdout
+
+
+def test_fingerprint_writes_markdown_to_output(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    output_dir = tmp_path / ".akira"
+    project.mkdir()
+    (project / "module.py").write_text(
+        '''import os
+
+
+def load_value(name: str) -> str:
+    if not name:
+        return "fallback"
+    return f"Hello {name}"
+''',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "fingerprint",
+            "--path",
+            str(project),
+            "--sample-size",
+            "5",
+            "--output",
+            str(output_dir),
+        ],
+    )
+
+    fingerprint_path = output_dir / "fingerprint.md"
+    content = fingerprint_path.read_text(encoding="utf-8")
+    assert result.exit_code == 0
+    assert fingerprint_path.exists()
+    assert "sample_size: 5" in content
+    assert '  - "module.py"' in content
+    assert "confidence:" in content
+    assert "## Spacing" in content
+    assert "## Control Flow" in content
+    assert "## General Patterns" in content
 
 
 def test_detect_rejects_invalid_path() -> None:
@@ -192,6 +239,7 @@ def test_wheel_build_includes_jinja_templates(tmp_path: Path) -> None:
         names = set(archive.namelist())
 
     assert "akira/detect/templates/stack.md.j2" in names
+    assert "akira/fingerprint/templates/fingerprint.md.j2" in names
     assert "akira/skills/templates/base.md.j2" in names
     assert "akira/skills/templates/python/python.md.j2" in names
     assert "akira/skills/templates/python/testing/pytest.md.j2" in names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def test_fingerprint_help_documents_options() -> None:
     result = runner.invoke(app, ["fingerprint", "--help"])
 
     assert result.exit_code == 0
+    assert "write fingerprint.md output" in result.stdout
     assert "--path" in result.stdout
     assert "--sample-size" in result.stdout
     assert "--exclude" in result.stdout
@@ -97,9 +98,9 @@ def load_value(name: str) -> str:
     )
 
     fingerprint_path = output_dir / "fingerprint.md"
-    content = fingerprint_path.read_text(encoding="utf-8")
     assert result.exit_code == 0
     assert fingerprint_path.exists()
+    content = fingerprint_path.read_text(encoding="utf-8")
     assert "sample_size: 5" in content
     assert '  - "module.py"' in content
     assert "confidence:" in content
@@ -146,6 +147,21 @@ def test_detect_rejects_output_file(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["detect", "--path", str(tmp_path), "--output", str(output_file)],
+    )
+    output = f"{result.stdout}\n{result.stderr}"
+
+    assert result.exit_code != 0
+    assert output_file.name in output
+    assert "file" in output.lower()
+
+
+def test_fingerprint_rejects_output_file(tmp_path: Path) -> None:
+    output_file = tmp_path / "fingerprint.md"
+    output_file.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["fingerprint", "--path", str(tmp_path), "--output", str(output_file)],
     )
     output = f"{result.stdout}\n{result.stderr}"
 

--- a/tests/test_fingerprint/test_extractors.py
+++ b/tests/test_fingerprint/test_extractors.py
@@ -121,6 +121,221 @@ def load_value():
     assert patterns["todo_format"].confidence == 1.0
 
 
+def test_typing_extractor_reports_signature_and_optional_conventions(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+def load_user(user_id: str, tags: Iterable[str] | None = None) -> Mapping[str, str]:
+    return {"id": user_id, "tags": ",".join(tags or [])}
+
+
+def _coerce_name(value: str | None) -> str:
+    return value or "anonymous"
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["signature_coverage"].value == "full_signature_hints"
+    assert patterns["signature_coverage"].confidence == 1.0
+    assert patterns["return_hints"].confidence == 1.0
+    assert patterns["optional_syntax"].value == "pipe_union_none"
+    assert patterns["complex_type_imports"].value == ("Iterable", "Mapping")
+
+
+def test_structure_extractor_reports_control_flow_shape(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''def classify(value: int) -> str:
+    if value < 0:
+        return "negative"
+    if value == 0:
+        return "zero"
+
+    label = "large" if value > 10 else "small"
+    return label
+
+
+def nested(items: list[int]) -> int:
+    total = 0
+    for item in items:
+        if item > 0:
+            total += item
+    return total
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["early_returns"].value == "occasional"
+    assert patterns["early_returns"].confidence == 0.5
+    assert patterns["guard_clauses"].value == "occasional"
+    assert patterns["nesting_depth"].value in {1, 2}
+    assert patterns["ternary_usage"].value == "uses_ternary"
+    assert patterns["function_length"].value == "under_30_lines"
+
+
+def test_docstring_extractor_reports_style_and_visibility(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''class Service:
+    """Load user-facing values.
+
+    Args:
+        source: Source name.
+    """
+
+    def public_method(self, source: str) -> str:
+        """Return a normalized value.
+
+        Args:
+            source: Source name.
+
+        Returns:
+            Normalized source.
+        """
+        return source.lower()
+
+    def _private_method(self) -> None:
+        return None
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["public_docstrings"].value == "documented"
+    assert patterns["public_docstrings"].confidence == 1.0
+    assert patterns["private_docstring_behavior"].value == "omit_private_docstrings"
+    assert patterns["docstring_style"].value == "google"
+    assert patterns["class_docstrings"].confidence == 1.0
+
+
+def test_organization_extractor_reports_module_and_class_order(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''"""Example module."""
+
+import os
+
+MAX_RETRIES = 3
+
+
+class Payload(dict):
+    pass
+
+
+def _coerce(value: str) -> str:
+    return value.strip()
+
+
+def load(value: str) -> str:
+    return _coerce(value)
+
+
+class Service:
+    timeout = 5
+
+    def __init__(self) -> None:
+        self.ready = True
+
+    def run(self) -> None:
+        return None
+
+    def _reset(self) -> None:
+        self.ready = False
+
+
+if __name__ == "__main__":
+    print(load(" demo "))
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["module_order"].value == (
+        "module_docstring",
+        "imports",
+        "constants",
+        "classes",
+        "private_helpers",
+        "public_functions",
+        "main_block",
+    )
+    assert patterns["helper_placement"].confidence == 1.0
+    assert patterns["class_member_order"].value == (
+        "attributes",
+        "constructor",
+        "public_methods",
+        "private_methods",
+    )
+    assert patterns["main_block"].confidence == 1.0
+
+
+def test_error_and_string_extractors_report_idioms(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def render(name: str) -> str:
+    message = f"Hello {name}"
+    template = """User:
+{name}
+"""
+    return message + template
+
+
+def load(path: str) -> str:
+    try:
+        return open(path, encoding="utf-8").read()
+    except FileNotFoundError:
+        LOGGER.exception("Could not load %s", path)
+        raise
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["exception_specificity"].confidence == 1.0
+    assert patterns["logging_on_catch"].confidence == 1.0
+    assert patterns["reraising"].confidence == 1.0
+    assert patterns["quote_style"].value == "double"
+    assert patterns["interpolation_style"].value == "f_strings"
+    assert patterns["multiline_strings"].value == "triple_double"
+
+
+def test_new_extractors_tolerate_files_with_missing_ast(tmp_path: Path) -> None:
+    (tmp_path / "valid.py").write_text(
+        '''def load(value: str | None) -> str:
+    if value is None:
+        return "fallback"
+    return value
+''',
+        encoding="utf-8",
+    )
+    (tmp_path / "broken.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+    analysis = fingerprint_project(tmp_path)
+    patterns = _patterns_by_name(analysis.patterns)
+
+    assert analysis.failed_files
+    assert patterns["signature_coverage"].value == "full_signature_hints"
+    assert patterns["early_returns"].confidence == 1.0
+
+
 def test_confidence_decreases_for_intentionally_mixed_style(tmp_path: Path) -> None:
     consistent = tmp_path / "consistent"
     mixed = tmp_path / "mixed"

--- a/tests/test_fingerprint/test_extractors.py
+++ b/tests/test_fingerprint/test_extractors.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from akira.fingerprint import extract_style_patterns, fingerprint_project
+from akira.fingerprint.models import StylePattern
+
+
+def test_spacing_extractor_reports_blank_line_conventions(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''import os
+import sys
+
+
+CONSTANT = 1
+
+
+class Service:
+    def first_method(self):
+        value = 1
+
+        return value
+
+    def second_method(self):
+        return 2
+
+
+def helper_function():
+    value = 3
+
+    return value
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["top_level_definitions"].value == 2
+    assert patterns["top_level_definitions"].confidence == 1.0
+    assert patterns["methods"].value == 1
+    assert patterns["after_imports"].value == 2
+    assert patterns["logical_blocks"].value == 1
+
+
+def test_naming_extractor_reports_symbol_conventions(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''MAX_RETRIES = 3
+is_enabled = True
+
+
+class UserService:
+    def _build_payload(self, user_name: str) -> dict[str, str]:
+        has_access: bool = True
+        payload_data = {"name": user_name}
+        return payload_data
+
+
+def load_user(user_id: str) -> str:
+    should_retry = False
+    return user_id
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["functions"].value == "snake_case"
+    assert patterns["variables"].value == "snake_case"
+    assert patterns["classes"].value == "PascalCase"
+    assert patterns["constants"].value == "UPPER_SNAKE_CASE"
+    assert patterns["private_helpers"].value == "single_leading_underscore"
+    assert "has_" in patterns["boolean_prefixes"].value
+    assert "should_" in patterns["boolean_prefixes"].value
+
+
+def test_import_extractor_reports_grouping_and_safety_conventions(tmp_path: Path) -> None:
+    package = tmp_path / "src" / "demo"
+    package.mkdir(parents=True)
+    (package / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (package / "main.py").write_text(
+        '''import os
+import sys
+
+import fastapi
+
+from demo.helpers import VALUE
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["grouping_order"].value == ("stdlib", "third_party", "local")
+    assert patterns["grouping_order"].confidence == 1.0
+    assert patterns["alphabetical_order"].confidence == 1.0
+    assert patterns["one_import_per_line"].confidence == 1.0
+    assert patterns["wildcard_usage"].value == "avoid_wildcards"
+    assert patterns["relative_imports"].value == "avoid_relative_imports"
+
+
+def test_comment_extractor_reports_comment_style_dimensions(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''# --- Public helpers ---
+# TODO(joel): use the shared fixture later
+def load_value():
+    value = 1
+    return value  # return the stable value
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["section_separators"].value == "hash_dash_section_separator"
+    assert patterns["section_separators"].confidence > 0
+    assert patterns["inline_comment_frequency"].value == "present"
+    assert patterns["language"].value == "english"
+    assert patterns["todo_format"].confidence == 1.0
+
+
+def test_confidence_decreases_for_intentionally_mixed_style(tmp_path: Path) -> None:
+    consistent = tmp_path / "consistent"
+    mixed = tmp_path / "mixed"
+    consistent.mkdir()
+    mixed.mkdir()
+
+    (consistent / "module.py").write_text(
+        '''import os
+
+
+def first_function():
+    return 1
+
+
+def second_function():
+    return 2
+''',
+        encoding="utf-8",
+    )
+    (mixed / "module.py").write_text(
+        '''import os
+
+
+def first_function():
+    return 1
+
+def secondFunction():
+    return 2
+''',
+        encoding="utf-8",
+    )
+
+    consistent_patterns = _patterns_by_name(fingerprint_project(consistent).patterns)
+    mixed_patterns = _patterns_by_name(fingerprint_project(mixed).patterns)
+
+    assert mixed_patterns["top_level_definitions"].confidence < consistent_patterns[
+        "top_level_definitions"
+    ].confidence
+    assert mixed_patterns["functions"].confidence < consistent_patterns[
+        "functions"
+    ].confidence
+
+
+def test_extract_style_patterns_is_deterministic(tmp_path: Path) -> None:
+    (tmp_path / "module.py").write_text(
+        '''import os
+
+
+VALUE = 1
+
+
+def load_value():
+    return VALUE
+''',
+        encoding="utf-8",
+    )
+
+    first = fingerprint_project(tmp_path)
+    second = fingerprint_project(tmp_path)
+
+    assert extract_style_patterns(first) == extract_style_patterns(second)
+    assert first.patterns == second.patterns
+
+
+def _patterns_by_name(patterns: tuple[StylePattern, ...]) -> dict[str, StylePattern]:
+    return {pattern.name: pattern for pattern in patterns}

--- a/tests/test_fingerprint/test_extractors.py
+++ b/tests/test_fingerprint/test_extractors.py
@@ -183,6 +183,55 @@ def nested(items: list[int]) -> int:
     assert patterns["function_length"].value == "under_30_lines"
 
 
+def test_structure_extractor_ignores_nested_scopes_for_outer_function_shape(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''def outer(flag: bool) -> int:
+    def inner() -> int:
+        if flag:
+            if not flag:
+                return 1
+            return 2
+        return 3
+
+    return inner()
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["early_returns"].confidence == 0.5
+    assert patterns["nesting_depth"].evidence["distribution"] == {0: 1, 2: 1}
+
+
+def test_ternary_confidence_counts_functions_not_expressions(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''def with_ternaries(first: bool, second: bool) -> tuple[str, str]:
+    left = "yes" if first else "no"
+    right = "up" if second else "down"
+    return left, right
+
+
+def without_ternary() -> str:
+    return "plain"
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert patterns["ternary_usage"].value == "uses_ternary"
+    assert patterns["ternary_usage"].confidence == 0.5
+    assert patterns["ternary_usage"].evidence == {
+        "ternary_expressions": 2,
+        "functions_with_ternary": 1,
+    }
+
+
 def test_docstring_extractor_reports_style_and_visibility(tmp_path: Path) -> None:
     source = tmp_path / "module.py"
     source.write_text(
@@ -279,6 +328,27 @@ if __name__ == "__main__":
         "private_methods",
     )
     assert patterns["main_block"].confidence == 1.0
+
+
+def test_organization_extractor_only_treats_eq_main_compare_as_main_guard(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''def load() -> str:
+    return "ok"
+
+
+if __name__ != "__main__":
+    load()
+''',
+        encoding="utf-8",
+    )
+
+    patterns = _patterns_by_name(fingerprint_project(tmp_path).patterns)
+
+    assert "main_block" not in patterns
+    assert patterns["module_order"].value == ("public_functions",)
 
 
 def test_error_and_string_extractors_report_idioms(tmp_path: Path) -> None:

--- a/tests/test_fingerprint/test_renderer.py
+++ b/tests/test_fingerprint/test_renderer.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from akira.fingerprint import fingerprint_project, render_fingerprint_markdown
+
+
+def test_render_fingerprint_markdown_includes_frontmatter_and_v1_sections(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''# --- Public helpers ---
+import os
+
+
+MAX_RETRIES = 3
+
+
+class UserService:
+    """Load users.
+
+    Args:
+        source: Source name.
+    """
+
+    def _build_payload(self, user_name: str | None) -> dict[str, str]:
+        if user_name is None:
+            return {"name": "anonymous"}
+        return {"name": f"{user_name}"}
+
+
+def load_user(user_id: str) -> str:
+    return user_id
+''',
+        encoding="utf-8",
+    )
+
+    analysis = fingerprint_project(tmp_path)
+    content = render_fingerprint_markdown(
+        analysis,
+        generated_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+        sample_size=20,
+    )
+
+    assert 'generated_at: "2026-05-02T12:00:00+00:00"' in content
+    assert "sample_size: 20" in content
+    assert '  - "module.py"' in content
+    assert "confidence:" in content
+    assert "- **Between top-level definitions**: 2 blank lines" in content
+    assert "- **Classes**: PascalCase" in content
+    assert "- **Optional style**: `X | None`" in content
+
+    for section in (
+        "Spacing",
+        "Comments",
+        "Control Flow",
+        "Naming",
+        "Imports",
+        "Type Hints",
+        "Docstrings",
+        "Error Handling",
+        "Organization",
+        "Strings",
+        "General Patterns",
+    ):
+        assert f"## {section}" in content

--- a/tests/test_fingerprint/test_renderer.py
+++ b/tests/test_fingerprint/test_renderer.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from akira.fingerprint import fingerprint_project, render_fingerprint_markdown
+from akira.fingerprint.models import FingerprintAnalysis
 
 
 def test_render_fingerprint_markdown_includes_frontmatter_and_v1_sections(
@@ -51,6 +52,8 @@ def load_user(user_id: str) -> str:
     assert "- **Between top-level definitions**: 2 blank lines" in content
     assert "- **Classes**: PascalCase" in content
     assert "- **Optional style**: `X | None`" in content
+    assert "- **Functions**: Sparse" in content
+    assert "- **Max nesting**: 0 levels" in content
 
     for section in (
         "Spacing",
@@ -66,3 +69,44 @@ def load_user(user_id: str) -> str:
         "General Patterns",
     ):
         assert f"## {section}" in content
+
+
+def test_render_fingerprint_markdown_uses_empty_files_list_for_empty_samples(
+    tmp_path: Path,
+) -> None:
+    analysis = FingerprintAnalysis(project_root=tmp_path, files=(), patterns=())
+
+    content = render_fingerprint_markdown(analysis, sample_size=0)
+
+    assert "sample_size: 0" in content
+    assert "files_analyzed: []" in content
+
+
+def test_render_fingerprint_markdown_preserves_identifier_like_values(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        '''from typing import ClassVar, TypedDict
+
+
+class Payload(TypedDict):
+    name: str
+
+
+class Service:
+    retries: ClassVar[int] = 3
+
+
+def load_payload(has_access: bool, should_retry: bool) -> Payload:
+    has_value = True
+    should_log = False
+    return {"name": "ok"}
+''',
+        encoding="utf-8",
+    )
+
+    content = render_fingerprint_markdown(fingerprint_project(tmp_path))
+
+    assert "- **Boolean variables**: has_ -> should_" in content
+    assert "- **Complex type imports**: ClassVar -> TypedDict" in content

--- a/tests/test_fingerprint/test_style_fixtures.py
+++ b/tests/test_fingerprint/test_style_fixtures.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from akira.detect.models import Signal, StackInfo
+from akira.fingerprint import (
+    analyze_project,
+    fingerprint_project,
+    render_fingerprint_markdown,
+)
+from akira.fingerprint.extractors import (
+    comments,
+    docstrings,
+    error_handling,
+    imports,
+    naming,
+    organization,
+    spacing,
+    strings,
+    structure,
+    typing,
+)
+from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+from akira.skills.generator import generate_skills
+
+
+def test_style_fixtures_cover_major_fingerprint_dimensions(fixtures_dir: Path) -> None:
+    analysis = fingerprint_project(fixtures_dir / "style_projects" / "consistent")
+
+    dimensions = {pattern.dimension for pattern in analysis.patterns}
+
+    assert dimensions >= {
+        "spacing",
+        "naming",
+        "imports",
+        "comments",
+        "typing",
+        "structure",
+        "docstrings",
+        "organization",
+        "error_handling",
+        "strings",
+    }
+
+
+def test_individual_extractors_report_expected_fixture_patterns(
+    fixtures_dir: Path,
+) -> None:
+    analysis = analyze_project(fixtures_dir / "style_projects" / "consistent")
+
+    expected_names_by_extractor = {
+        spacing.extract: {"top_level_definitions", "methods", "logical_blocks"},
+        naming.extract: {"functions", "classes", "private_helpers"},
+        imports.extract: {"grouping_order", "wildcard_usage", "relative_imports"},
+        comments.extract: {"section_separators", "inline_comment_frequency"},
+        typing.extract: {"signature_coverage", "optional_syntax"},
+        structure.extract: {"early_returns", "guard_clauses", "function_length"},
+        docstrings.extract: {"docstring_style", "public_docstrings"},
+        organization.extract: {"module_order", "helper_placement"},
+        error_handling.extract: {"exception_specificity", "logging_on_catch", "reraising"},
+        strings.extract: {"quote_style", "interpolation_style", "multiline_strings"},
+    }
+
+    for extractor, expected_names in expected_names_by_extractor.items():
+        patterns = extractor(analysis)
+        actual_names = {pattern.name for pattern in patterns}
+        assert actual_names >= expected_names
+
+
+def test_consistent_style_fixture_has_high_confidence_patterns(
+    fixtures_dir: Path,
+) -> None:
+    patterns = _patterns_by_name(
+        fingerprint_project(fixtures_dir / "style_projects" / "consistent").patterns
+    )
+
+    assert patterns["logical_blocks"].value == 1
+    assert patterns["logical_blocks"].confidence == 1.0
+    assert patterns["variables"].value == "snake_case"
+    assert patterns["variables"].confidence == 1.0
+    assert patterns["signature_coverage"].value == "full_signature_hints"
+    assert patterns["signature_coverage"].confidence == 1.0
+    assert patterns["optional_syntax"].value == "pipe_union_none"
+    assert patterns["exception_specificity"].confidence == 1.0
+    assert patterns["logging_on_catch"].confidence == 1.0
+    assert patterns["reraising"].confidence == 1.0
+
+
+def test_mixed_style_fixture_lowers_aggregate_and_dimension_confidence(
+    fixtures_dir: Path,
+) -> None:
+    consistent = fingerprint_project(fixtures_dir / "style_projects" / "consistent")
+    mixed = fingerprint_project(fixtures_dir / "style_projects" / "mixed")
+    consistent_patterns = _patterns_by_name(consistent.patterns)
+    mixed_patterns = _patterns_by_name(mixed.patterns)
+
+    assert mixed.confidence < consistent.confidence
+    assert mixed_patterns["functions"].confidence < consistent_patterns["functions"].confidence
+    assert mixed_patterns["grouping_order"].confidence < consistent_patterns[
+        "grouping_order"
+    ].confidence
+    assert mixed_patterns["signature_coverage"].confidence < consistent_patterns[
+        "signature_coverage"
+    ].confidence
+    assert mixed_patterns["public_docstrings"].confidence < consistent_patterns[
+        "public_docstrings"
+    ].confidence
+
+
+def test_syntax_error_fixture_is_represented_without_blocking_patterns(
+    fixtures_dir: Path,
+) -> None:
+    analysis = fingerprint_project(fixtures_dir / "style_projects" / "with_syntax_error")
+    patterns = _patterns_by_name(analysis.patterns)
+
+    assert [file.relative_path.as_posix() for file in analysis.failed_files] == [
+        "src/style_app/broken.py"
+    ]
+    assert "line 1" in analysis.failed_files[0].parse_error
+    assert [file.relative_path.as_posix() for file in analysis.parsed_files] == [
+        "src/style_app/valid.py"
+    ]
+    assert patterns["signature_coverage"].value == "full_signature_hints"
+    assert patterns["early_returns"].value == "preferred"
+
+
+def test_fixture_rendered_fingerprint_markdown_is_verified(
+    fixtures_dir: Path,
+) -> None:
+    analysis = fingerprint_project(fixtures_dir / "style_projects" / "consistent")
+
+    content = render_fingerprint_markdown(
+        analysis,
+        generated_at=datetime(2026, 5, 2, 12, 30, tzinfo=timezone.utc),
+        sample_size=20,
+    )
+
+    assert 'generated_at: "2026-05-02T12:30:00+00:00"' in content
+    assert '  - "src/style_app/helpers.py"' in content
+    assert '  - "src/style_app/service.py"' in content
+    assert "- **Inside functions**: 1 blank line" in content
+    assert "- **Variables**: snake_case" in content
+    assert "- **Coverage**: Full function signature hints" in content
+    assert "- **Optional style**: `X | None`" in content
+    assert "- **Logging on catch**: Logs caught exceptions" in content
+    assert "## Organization" in content
+    assert "## Strings" in content
+
+
+def test_fingerprint_core_rules_are_included_in_generated_router(
+    fixtures_dir: Path,
+    tmp_path: Path,
+) -> None:
+    project = fixtures_dir / "style_projects" / "consistent"
+    output = tmp_path / ".akira"
+    stack = StackInfo.from_signals(
+        project,
+        (
+            Signal(tool="pytest", category="testing", source="fixture"),
+            Signal(tool="ruff", category="tooling", source="fixture"),
+        ),
+    )
+    analysis = fingerprint_project(project)
+
+    generate_skills(stack, output, fingerprint=analysis)
+
+    router = (output / "skills" / "SKILL.md").read_text(encoding="utf-8")
+    assert "Read `python/testing/pytest.md`" in router
+    assert "Use 1 blank line between logical blocks inside functions." in router
+    assert "Use full type hints on function signatures." in router
+    assert "Use `X | None` syntax for optional values." in router
+    assert "Prefer the conventions already present in the repository." in router
+
+
+def _patterns_by_name(patterns: tuple[StylePattern, ...]) -> dict[str, StylePattern]:
+    return {pattern.name: pattern for pattern in patterns}

--- a/tests/test_fingerprint/test_style_fixtures.py
+++ b/tests/test_fingerprint/test_style_fixtures.py
@@ -21,7 +21,7 @@ from akira.fingerprint.extractors import (
     structure,
     typing,
 )
-from akira.fingerprint.models import FingerprintAnalysis, StylePattern
+from akira.fingerprint.models import StylePattern
 from akira.skills.generator import generate_skills
 
 

--- a/tests/test_skills/test_skill_generator.py
+++ b/tests/test_skills/test_skill_generator.py
@@ -6,6 +6,7 @@ import yaml
 
 from akira.detect import scan_project
 from akira.detect.models import Signal, StackInfo
+from akira.fingerprint import fingerprint_project
 from akira.skills.generator import generate_skills
 
 
@@ -159,6 +160,66 @@ def test_root_router_uses_fingerprint_placeholder_when_missing(
     assert "`fingerprint.md` may not exist yet" in router
     assert "preserve the" in router
     assert "conventions already present in nearby files" in router
+
+
+def test_root_router_includes_core_rules_from_structured_fingerprint(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "module.py").write_text(
+        '''from __future__ import annotations
+
+import os
+import sys
+
+
+def build_name(value: str | None) -> str:
+    if value is None:
+        return "anonymous"
+
+    return f"{value}"
+''',
+        encoding="utf-8",
+    )
+    stack = StackInfo.from_signals(
+        project,
+        [Signal("python", "runtime", version="3.12", source="test")],
+    )
+    output = tmp_path / ".akira"
+    analysis = fingerprint_project(project)
+
+    generate_skills(stack, output, fingerprint=analysis)
+
+    router = (output / "skills" / "SKILL.md").read_text(encoding="utf-8")
+    assert "## Core Rules From Fingerprint" in router
+    assert "- Prefer early returns over deeply nested branches." in router
+    assert "- Put guard clauses near the top of functions." in router
+    assert "- Use full type hints on function signatures." in router
+    assert "- Use `X | None` syntax for optional values." in router
+    assert "Treat `fingerprint.md` as the source of truth" not in router
+    assert "`fingerprint.md` may not exist yet" not in router
+
+
+def test_root_router_handles_existing_fingerprint_without_stable_rules(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    output = tmp_path / ".akira"
+    output.mkdir()
+    (output / "fingerprint.md").write_text("# Developer Fingerprint\n", encoding="utf-8")
+    stack = StackInfo.from_signals(
+        project,
+        [Signal("python", "runtime", version="3.12", source="test")],
+    )
+
+    generate_skills(stack, output)
+
+    router = (output / "skills" / "SKILL.md").read_text(encoding="utf-8")
+    assert "`fingerprint.md` exists" in router
+    assert "enough high-confidence" in router
+    assert "`fingerprint.md` may not exist yet" not in router
 
 
 def test_root_router_changes_active_sub_skills_for_different_stacks(

--- a/tests/test_skills/test_skill_generator.py
+++ b/tests/test_skills/test_skill_generator.py
@@ -198,14 +198,24 @@ def build_name(value: str | None) -> str:
     assert "- Use full type hints on function signatures." in router
     assert "- Use `X | None` syntax for optional values." in router
     assert "Treat `fingerprint.md` as the source of truth" not in router
+    assert "`fingerprint.md` exists" not in router
     assert "`fingerprint.md` may not exist yet" not in router
 
 
-def test_root_router_handles_existing_fingerprint_without_stable_rules(
+def test_root_router_does_not_rescan_when_only_fingerprint_file_exists(
     tmp_path: Path,
 ) -> None:
     project = tmp_path / "project"
     project.mkdir()
+    (project / "module.py").write_text(
+        '''def build_name(value: str | None) -> str:
+    if value is None:
+        return "anonymous"
+
+    return f"{value}"
+''',
+        encoding="utf-8",
+    )
     output = tmp_path / ".akira"
     output.mkdir()
     (output / "fingerprint.md").write_text("# Developer Fingerprint\n", encoding="utf-8")
@@ -219,6 +229,7 @@ def test_root_router_handles_existing_fingerprint_without_stable_rules(
     router = (output / "skills" / "SKILL.md").read_text(encoding="utf-8")
     assert "`fingerprint.md` exists" in router
     assert "enough high-confidence" in router
+    assert "Prefer early returns" not in router
     assert "`fingerprint.md` may not exist yet" not in router
 
 


### PR DESCRIPTION
## Description

Milestone **Altair** — Developer fingerprint: style extraction, rendering, and skill integration.

This PR delivers the complete fingerprint pipeline. After this merge, `akira fingerprint` analyzes a Python codebase across 10 style dimensions, generates `.akira/fingerprint.md` with the developer's coding patterns, and feeds core rules directly into the router SKILL.md so the agent respects the dev's personal style when writing code.

Closes #14, #15, #16, #17, #18

## Changes

- **Core extractors** (#14): `SpacingExtractor` (blank lines between definitions and logical blocks), `NamingExtractor` (conventions for functions, variables, classes, constants), `ImportsExtractor` (grouping order and style preferences), `CommentsExtractor` (comment formats and placement). Introduced `StylePattern` model and confidence metrics in `FingerprintAnalysis`. Simplified dominant import sequence extraction logic.
- **Advanced extractors** (#15): `TypingExtractor` (type hint coverage, signature style, `Optional` vs union syntax), `StructureExtractor` (early returns, guard clauses, nesting depth, ternary usage per function), `ErrorHandlingExtractor` (exception specificity, logging-on-catch patterns), `DocstringsExtractor` (Google/NumPy/Sphinx style detection, coverage ratio), `OrganizationExtractor` (module element ordering, `if __name__` guard detection), `StringsExtractor` (quote style, f-string vs `.format()` preference). Improved nested scope handling and refined main guard detection.
- **Fingerprint rendering** (#16): `renderer.py` producing `.akira/fingerprint.md` via Jinja2 template. `write_fingerprint_markdown` function with `--output` CLI option. Graceful handling of empty file scenarios.
- **Skill integration** (#17): `format_fingerprint_value` for clean Markdown formatting of style values. `SkillGenerator` updated to accept `FingerprintAnalysis` and inject core rules into the router SKILL.md template. Fingerprint existence determined by file presence rather than re-running analysis.
- **Validation suite** (#18): Style fixture projects (consistent, mixed, syntax-error) with end-to-end fingerprint analysis tests. Ruff exclusions for intentionally non-compliant fixtures.

## Motivation

The fingerprint is what makes Akira personal. Generic skill tools tell the agent *what* tools to use; the fingerprint tells it *how you write code*. With this milestone, the full detect → fingerprint → generate → install pipeline is connected: the agent now receives both project conventions and developer style preferences in a single, coherent skill tree.

## Type of Change

- [x] New feature (non-breaking)
- [x] Tests added
- [ ] Breaking change
- [ ] Documentation only

## Checklist

- [x] Code follows the project's style guidelines
- [x] All 10 style extractors tested individually
- [x] Fingerprint markdown renders correctly for consistent, mixed, and edge-case codebases
- [x] Core rules propagate into router SKILL.md
- [x] Ruff exclusions configured for intentionally non-compliant test fixtures
- [x] No breaking changes introduced